### PR TITLE
Towards MODGOBI-7: Add mod-orders module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -15,13 +15,16 @@
           "methods": ["POST"],
           "pathPattern": "/gobi/orders",
           "permissionsRequired": ["gobi.item.post"],
-          "modulePermissions": [
-          ]
+          "modulePermissions": [ "orders.item.post" ]
         }
       ]
     }
   ],
   "requires": [
+    {
+      "id": "orders",
+      "version": "1.0"
+    }
   ],
   "permissionSets": [
     {


### PR DESCRIPTION
Updated mod-gobi to depend on "orders 1.0" and provide the permission required to post a purchase order to mod-orders.