### PR TITLE
MODGOBI-23 (Combinators)

### DIFF
--- a/src/main/java/org/folio/gobi/HelperUtils.java
+++ b/src/main/java/org/folio/gobi/HelperUtils.java
@@ -1,5 +1,8 @@
 package org.folio.gobi;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletionException;
 
 import org.folio.gobi.exceptions.HttpException;
@@ -13,15 +16,15 @@ public class HelperUtils {
 
   }
 
-  public static String truncate(String message, int limit) {    
+  public static String truncate(String message, int limit) {
     return (message != null && limit > 0) ? message.substring(0, Math.min(message.length(), limit)) : message;
   }
 
   public static JsonObject verifyAndExtractBody(org.folio.rest.tools.client.Response response) {
-    if(response == null) {
-      throw new CompletionException(new NullPointerException("response is null")); 
+    if (response == null) {
+      throw new CompletionException(new NullPointerException("response is null"));
     }
-    
+
     if (!org.folio.rest.tools.client.Response.isSuccess(response.getCode())) {
       throw new CompletionException(new HttpException(response.getCode(), response.getError().toString()));
     }
@@ -42,9 +45,9 @@ public class HelperUtils {
   }
 
   public static String extractIdOfFirst(JsonObject obj, String arrField) {
-    if(obj == null || arrField == null || arrField.isEmpty()) {
-      return null;  
-    }    
+    if (obj == null || arrField == null || arrField.isEmpty()) {
+      return null;
+    }
     JsonArray jsonArray = obj.getJsonArray(arrField);
     if (jsonArray == null) {
       return null;
@@ -54,5 +57,9 @@ public class HelperUtils {
       return null;
     }
     return item.getString("id");
+  }
+
+  public static String encodeValue(String value) throws UnsupportedEncodingException {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
   }
 }

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -109,7 +109,7 @@ public class Mapper {
         .exceptionally(Mapper::logException));
       futures.add(mappings.get(Field.LOCATION)
         .resolve(doc)
-        .thenAccept(o -> location.setId((String) o))
+        .thenAccept(o -> location.setLocationId((String) o))
         .exceptionally(Mapper::logException));
       futures.add(mappings.get(Field.QUANTITY)
         .resolve(doc)

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -140,7 +140,7 @@ public class Mapper {
         .exceptionally(Mapper::logException));
       futures.add(mappings.get(Field.VENDOR_ID)
         .resolve(doc)
-        .thenAccept(o -> vendor.setId((String) o))
+        .thenAccept(o -> vendor.setRefNumber((String) o))
         .exceptionally(Mapper::logException));
       futures.add(mappings.get(Field.INSTRUCTIONS)
         .resolve(doc)

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -100,6 +100,7 @@ public class PostGobiOrdersHelper {
         .build());
       mappings.put(Field.TITLE, DataSource.builder()
         .withFrom("//datafield[@tag='245']/*")
+        .withCombinator(Mapper::concat)
         .build());
       mappings.put(Field.RECEIVING_NOTE, DataSource.builder()
         .withFrom("//LocalData[Description='LocalData2']/Value")

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -8,12 +8,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.apache.log4j.Logger;
+import org.folio.gobi.DataSource;
 import org.folio.gobi.GobiPurchaseOrderParser;
 import org.folio.gobi.GobiResponseWriter;
 import org.folio.gobi.HelperUtils;
 import org.folio.gobi.Mapper;
 import org.folio.gobi.Mapper.Field;
-import org.folio.gobi.Mapping;
 import org.folio.gobi.exceptions.GobiPurchaseOrderParserException;
 import org.folio.gobi.exceptions.HttpException;
 import org.folio.gobi.exceptions.InvalidTokenException;
@@ -58,35 +58,90 @@ public class PostGobiOrdersHelper {
     VertxCompletableFuture<JsonObject> future = new VertxCompletableFuture<>(ctx);
 
     try {
-      Map<Field, Mapping> mappings = new EnumMap<>(Field.class);
+      Map<Field, DataSource> mappings = new EnumMap<>(Field.class);
 
-      mappings.put(Field.CREATED_BY,
-          new Mapping(null, getUuid(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN)), null));
-      mappings.put(Field.ACCOUNT_NUMBER, new Mapping("//SubAccount", 0, null));
-      mappings.put(Field.ACQUISITION_METHOD, new Mapping(null, "mod-gobi", null));
-      mappings.put(Field.QUANTITY, new Mapping("//Quantity", 1, Mapper::toInteger));
-      mappings.put(Field.LIST_PRICE, new Mapping("//ListPrice/Amount", 0d, Mapper::toDouble));
-      mappings.put(Field.ESTIMATED_PRICE,
-          new Mapping("//NetPrice/Amount", mappings.get(Field.LIST_PRICE), Mapper::toDouble));
-      mappings.put(Field.CURRENCY, new Mapping("//ListPrice/Currency", "USD", null));
-      mappings.put(Field.FUND_CODE, new Mapping("//FundCode", 0, null));
-      mappings.put(Field.TITLE, new Mapping("//datafield[@tag='245']/*", null, null));
-      mappings.put(Field.RECEIVING_NOTE, new Mapping("//LocalData[Description='LocalData2']/Value", null, null));
-      mappings.put(Field.REQUESTER, new Mapping("//LocalData[Description='LocalData3']/Value", null, null));
-      mappings.put(Field.ACCESS_PROVIDER, new Mapping("//PurchaseOrder/VendorPOCode", null, null));
-      mappings.put(Field.NOTE_FROM_VENDOR, new Mapping("//PurchaseOrder/VendorCode", null, null));
-      mappings.put(Field.PRODUCT_ID, new Mapping("//datafield[@tag='020']/subfield[@code='a']", null, null));
-      mappings.put(Field.MATERIAL_TYPE,
-          new Mapping("//LocalData[Description='LocalData1']/Value", null, this::lookupMaterialTypeId));
-      mappings.put(Field.LOCATION, new Mapping("//Location", null, this::lookupLocationId));
-      mappings.put(Field.VENDOR_ID, new Mapping(null, "GOBI", this::lookupVendorId, true));
-      mappings.put(Field.USER_LIMIT, new Mapping("//PurchaseOption/Code", null, s -> {
-        if (s != null) {
-          return CompletableFuture.completedFuture(3);
-        } else {
-          return CompletableFuture.completedFuture(null);
-        }
-      }));
+      mappings.put(Field.CREATED_BY, DataSource.builder()
+        .withDefault(getUuid(okapiHeaders.get(RestVerticle.OKAPI_HEADER_TOKEN)))
+        .build());
+      mappings.put(Field.ACCOUNT_NUMBER, DataSource.builder()
+        .withFrom("//SubAccount")
+        .withDefault(0)
+        .build());
+      mappings.put(Field.ACQUISITION_METHOD, DataSource.builder()
+        .withDefault("mod-gobi")
+        .build());
+      mappings.put(Field.QUANTITY, DataSource.builder()
+        .withFrom("//Quantity")
+        .withDefault(1)
+        .withTranslation(Mapper::toInteger)
+        .build());
+      mappings.put(Field.LIST_PRICE, DataSource.builder()
+        .withFrom("//ListPrice/Amount")
+        .withDefault(0d)
+        .withTranslation(Mapper::toDouble)
+        .build());
+      mappings.put(Field.ESTIMATED_PRICE, DataSource.builder()
+        .withFrom("//NetPrice/Amount")
+        .withDefault(DataSource.builder()
+          .withFrom("//ListPrice/Amount|//Quantity")
+          .withCombinator(Mapper::multiply)
+          .withDefault(mappings.get(Field.LIST_PRICE))
+          .build())
+        .withTranslation(Mapper::toDouble)
+        .build());
+      mappings.put(Field.CURRENCY, DataSource.builder()
+        .withFrom("//ListPrice/Currency")
+        .withDefault("USD")
+        .build());
+      mappings.put(Field.FUND_CODE, DataSource.builder()
+        .withFrom("//FundCode")
+        .withDefault(0)
+        .build());
+      mappings.put(Field.TITLE, DataSource.builder()
+        .withFrom("//datafield[@tag='245']/*")
+        .build());
+      mappings.put(Field.RECEIVING_NOTE, DataSource.builder()
+        .withFrom("//LocalData[Description='LocalData2']/Value")
+        .build());
+      mappings.put(Field.REQUESTER, DataSource.builder()
+        .withFrom("//LocalData[Description='LocalData3']/Value")
+        .build());
+      mappings.put(Field.ACCESS_PROVIDER, DataSource.builder()
+        .withFrom("//PurchaseOrder/VendorPOCode")
+        .build());
+      mappings.put(Field.NOTE_FROM_VENDOR, DataSource.builder()
+        .withFrom("//PurchaseOrder/VendorCode")
+        .build());
+      mappings.put(Field.PRODUCT_ID, DataSource.builder()
+        .withFrom("//datafield[@tag='020']/subfield[@code='a']")
+        .build());
+      mappings.put(Field.MATERIAL_TYPE, DataSource.builder()
+        .withFrom("//LocalData[Description='LocalData1']/Value")
+        .withTranslation(this::lookupMaterialTypeId)
+        .build());
+      mappings.put(Field.LOCATION, DataSource.builder()
+        .withFrom("//Location")
+        .withTranslation(this::lookupLocationId)
+        .build());
+      mappings.put(Field.VENDOR_ID, DataSource.builder()
+        .withDefault("GOBI")
+        .withTranslation(this::lookupVendorId)
+        .withTranslateDefault(true)
+        .build());
+      mappings.put(Field.INSTRUCTIONS, DataSource.builder()
+        .withFrom("//OrderNotes")
+        .withDefault("")
+        .build());
+      mappings.put(Field.USER_LIMIT, DataSource.builder()
+        .withFrom("//PurchaseOption/Code")
+        .withTranslation(s -> {
+          if (s != null) {
+            return CompletableFuture.completedFuture(3);
+          } else {
+            return CompletableFuture.completedFuture(null);
+          }
+        })
+        .build());
 
       new Mapper(mappings).map(doc)
         .thenAccept(compPO -> future.complete(JsonObject.mapFrom(compPO)));

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -86,6 +86,7 @@ public class PostGobiOrdersHelper {
           .withFrom("//ListPrice/Amount|//Quantity")
           .withCombinator(Mapper::multiply)
           .withDefault(mappings.get(Field.LIST_PRICE))
+          .withTranslation(Mapper::toDouble)
           .build())
         .withTranslation(Mapper::toDouble)
         .build());
@@ -168,7 +169,7 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupLocationId(String location) {
     try {
-      String query = HelperUtils.encodeValue("code==" + location);
+      String query = HelperUtils.encodeValue(String.format("code=\"%s\"", location));
       return httpClient.request("/locations?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractLocationId)
@@ -184,7 +185,7 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupMaterialTypeId(String materialType) {
     try {
-      String query = HelperUtils.encodeValue("name==" + materialType);
+      String query = HelperUtils.encodeValue(String.format("name=\"%s\"", materialType));
       return httpClient.request("/material-types?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractMaterialTypeId)
@@ -201,7 +202,7 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupVendorId(String vendorCode) {
     try {
-      String query = HelperUtils.encodeValue("code==" + vendorCode);
+      String query = HelperUtils.encodeValue(String.format("code=\"%s\"", vendorCode));
       return httpClient.request(HttpMethod.GET, "/vendor?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractVendorId)

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -168,7 +168,8 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupLocationId(String location) {
     try {
-      return httpClient.request("/location?query=code==" + location, okapiHeaders)
+      String query = HelperUtils.encodeValue("code==" + location);
+      return httpClient.request("/location?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractLocationId)
         .exceptionally(t -> {
@@ -183,7 +184,8 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupMaterialTypeId(String materialType) {
     try {
-      return httpClient.request("/material-type?query=name==" + materialType, okapiHeaders)
+      String query = HelperUtils.encodeValue("name==" + materialType);
+      return httpClient.request("/material-type?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractMaterialTypeId)
         .exceptionally(t -> {
@@ -199,7 +201,8 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupVendorId(String vendorCode) {
     try {
-      return httpClient.request(HttpMethod.GET, "/vendor?query=code==" + vendorCode, okapiHeaders)
+      String query = HelperUtils.encodeValue("code==" + vendorCode);
+      return httpClient.request(HttpMethod.GET, "/vendor?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractVendorId)
         .exceptionally(t -> {

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -169,7 +169,7 @@ public class PostGobiOrdersHelper {
   public CompletableFuture<String> lookupLocationId(String location) {
     try {
       String query = HelperUtils.encodeValue("code==" + location);
-      return httpClient.request("/location?query=" + query, okapiHeaders)
+      return httpClient.request("/locations?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractLocationId)
         .exceptionally(t -> {
@@ -185,7 +185,7 @@ public class PostGobiOrdersHelper {
   public CompletableFuture<String> lookupMaterialTypeId(String materialType) {
     try {
       String query = HelperUtils.encodeValue("name==" + materialType);
-      return httpClient.request("/material-type?query=" + query, okapiHeaders)
+      return httpClient.request("/material-types?query=" + query, okapiHeaders)
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenApply(HelperUtils::extractMaterialTypeId)
         .exceptionally(t -> {

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -515,7 +515,7 @@ public class GOBIIntegrationServiceResourceImplTest {
         .put("mtypes", new JsonArray()
           .add(new JsonObject()
             .put("id", UUID.randomUUID().toString())
-            .put("name", ctx.queryParam("query").get(0).split("=")[2])))
+            .put("name", ctx.queryParam("query").get(0).split("=")[1])))
         .put("total_records", 1);
 
       ctx.response()
@@ -532,7 +532,7 @@ public class GOBIIntegrationServiceResourceImplTest {
         .put("locations", new JsonArray()
           .add(new JsonObject()
             .put("id", UUID.randomUUID().toString())
-            .put("code", ctx.queryParam("query").get(0).split("=")[2])))
+            .put("code", ctx.queryParam("query").get(0).split("=")[1])))
         .put("total_records", 1);
 
       ctx.response()

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -445,8 +445,8 @@ public class GOBIIntegrationServiceResourceImplTest {
       router.route().handler(BodyHandler.create());
       router.route(HttpMethod.POST, "/orders").handler(this::handlePostPurchaseOrder);
       router.route(HttpMethod.GET, "/vendor").handler(this::handleGetVendor);
-      router.route(HttpMethod.GET, "/material-type").handler(this::handleGetMaterialType);
-      router.route(HttpMethod.GET, "/location").handler(this::handleGetLocation);
+      router.route(HttpMethod.GET, "/material-types").handler(this::handleGetMaterialType);
+      router.route(HttpMethod.GET, "/locations").handler(this::handleGetLocation);
 
       return router;
     }

--- a/src/test/resources/Mapping/testdata.xml
+++ b/src/test/resources/Mapping/testdata.xml
@@ -7,5 +7,6 @@
     <Dah>Hello World</Dah>
   </Doo>
   <Zip>90210</Zip>
-  <Zap>1.5</Zap>   
+  <Zap>1.5</Zap>
+  <Zop>3</Zop>
 </Foo>


### PR DESCRIPTION
Several changes:

* Rename `Mapping` -> `DataSource`, and `Mapping.map()` to `DataSource.resolve()`
* [MODGOBI-23](https://issues.folio.org/browse/MODGOBI-23) Add an optional `Combinator` parameter.  This is a generalized way to combine multiple fields.
  * The idea is to specify an xpath expression that returns multiple nodes, and a combinator that tells the mapper how to combine them.  
  * e.g. Concatenate two or more strings, or multiply two or more numbers.
  * The main impetus for this was the estimated_price mapping...  It should be set to the value of `NetPrice` if present, or to `ListPrice * Quantity` if it isn't.  There wasn't any way to do this until now.
  * This also cleans up the most common code path (no combinator) by splitting the concatenation logic into a combinator that now needs to be explicitly specified in the mapping.
* Add ability to use `BigDecimal` since we're often dealing with currency and want more precise calculations
* Refactor `DataSource` to use the fluent builder pattern... was starting to getting into constructor hell
* URL Encode the CQL query strings, and wrap terms in double qoutes when performing lookups.  CQL was barfing on special characters in the terms... e.g. there were multiple `/` characters in the location code.
* Several minor mapping adjustments... set `quantity` in two places, add `vendor.instructions`, `location.id` -> `location.location_id`, etc.