### PR TITLE
add missing module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -15,7 +15,12 @@
           "methods": ["POST"],
           "pathPattern": "/gobi/orders",
           "permissionsRequired": ["gobi.item.post"],
-          "modulePermissions": [ "orders.item.post" ]
+          "modulePermissions": [
+            "orders.item.post",
+            "inventory-storage.material-types.collection.get",
+            "inventory-storage.locations.collection.get",
+            "vendor.collection.get"
+          ]
         }
       ]
     }


### PR DESCRIPTION
Add the following to POST /gobi/orders (Required for lookups)

- "inventory-storage.material-types.collection.get"
- "inventory-storage.locations.collection.get"
-  "vendor.collection.get"