### PR TITLE
Adding Mappings for serial Orders

### DIFF
--- a/src/main/resources/data-mapping.json
+++ b/src/main/resources/data-mapping.json
@@ -718,6 +718,624 @@
           }
         }
       ]
-    }
+    },
+    {
+			"orderType": "ListedPrintSerial",
+			"mappings": [
+				{
+					"field": "TITLE",
+					"dataSource": {
+						"from": "//datafield[@tag='245']/*",
+						"combinator": "concat"
+					}
+				},
+				{
+					"field": "PUBLISHER",
+					"dataSource": {
+						"from": "//datafield[@tag='260']/subfield[@code='b']"
+					}
+				},
+				{
+					"field": "FUND_CODE",
+					"dataSource": {
+						"from": "//FundCode",
+						"translation": "lookupFundId"
+					}
+				},
+				{
+					"field": "INSTRUCTIONS",
+					"dataSource": {
+						"from": "//OrderNotes"
+					}
+				},
+				{
+					"field": "QUANTITY",
+					"dataSource": {
+						"from": "//Quantity",
+						"default": "1",
+						"translation": "toInteger"
+					}
+				},
+				{
+					"field": "VENDOR_REF_NO",
+					"dataSource": {
+						"from": "//YBPOrderKey"
+					}
+				},
+				{
+					"field": "CREATED_DATE",
+					"dataSource": {
+						"from": "//OrderPlaced",
+						"translation": "toDate"
+					}
+				},
+				{
+					"field": "OWNER",
+					"dataSource": {
+						"from": "//BaseAccount",
+						"default": "Main"
+					}
+				},
+				{
+					"field": "APPROVAL_STATUS",
+					"dataSource": {
+						"default": "APPROVED",
+						"translation": "lookupWorkflowStatusId",
+						"translateDefault": true
+					}
+				},
+				{
+					"field": "VENDOR",
+					"dataSource": {
+						"default": "GOBI Library Solutions"
+					}
+				},
+				{
+					"field": "FUND_PERCENTAGE",
+					"dataSource": {
+						"default": "100"
+					}
+				},
+				{
+					"field": "PRODUCT_ID_TYPE",
+					"dataSource": {
+						"default": "ISBN"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_FROM_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_INTERVAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_TO_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RECEIPT_DUE",
+					"dataSource": {
+						"default": true
+					}
+				},
+				{
+					"field": "ACQUISITION_METHOD",
+					"dataSource": {
+						"default": "Purchase at Vendor System"
+					}
+				},
+				{
+					"field": "CLAIM",
+					"dataSource": {
+						"default": "true"
+					}
+				},
+				{
+					"field": "COLLECTION",
+					"dataSource": {
+						"default": false
+					}
+				},
+				{
+					"field": "PO_LINE_WORKFLOW_STATUS",
+					"dataSource": {
+						"default": "Order Sent"
+					}
+				},
+				{
+					"field": "PO_LINE_RECEIPT_STATUS",
+					"dataSource": {
+						"default": "Awaiting Receipt"
+					}
+				},
+				{
+					"field": "PO_LINE_PAYMENT_STATUS",
+					"dataSource": {
+						"default": "Awaiting Payment"
+					}
+				},
+				{
+					"field": "SOURCE_ID",
+					"dataSource": {
+						"default": "Loaded from Vendor (API)"
+					}
+				},
+				{
+					"field": "MANUAL_RENEWAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_CYCLE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_REVIEW_PERIOD",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_INTERVAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "VENDOR_REF_NO_TYPE",
+					"dataSource": {
+						"default": "Supplier's unique order line reference number"
+					}
+				}
+			]
+		},
+		{
+			"orderType": "ListedElectronicSerial",
+			"mappings": [
+				{
+					"field": "TITLE",
+					"dataSource": {
+						"from": "//datafield[@tag='245']/*",
+						"combinator": "concat"
+					}
+				},
+				{
+					"field": "PUBLISHER",
+					"dataSource": {
+						"from": "//datafield[@tag='260']/subfield[@code='b']"
+					}
+				},
+				{
+					"field": "FUND_CODE",
+					"dataSource": {
+						"from": "//FundCode",
+						"translation": "lookupFundId"
+					}
+				},
+				{
+					"field": "INSTRUCTIONS",
+					"dataSource": {
+						"from": "//OrderNotes"
+					}
+				},
+				{
+					"field": "QUANTITY",
+					"dataSource": {
+						"from": "//Quantity",
+						"default": "1",
+						"translation": "toInteger"
+					}
+				},
+				{
+					"field": "VENDOR_REF_NO",
+					"dataSource": {
+						"from": "//YBPOrderKey"
+					}
+				},
+				{
+					"field": "CREATED_DATE",
+					"dataSource": {
+						"from": "//OrderPlaced",
+						"translation": "toDate"
+					}
+				},
+				{
+					"field": "LIST_PRICE",
+					"dataSource": {
+						"from": "//ListPrice/Amount",
+						"default": "0",
+						"translation": "toDouble"
+					}
+				},
+				{
+					"field": "ESTIMATED_PRICE",
+					"dataSource": {
+						"from": "//ListPrice/Amount",
+						"defaultMapping": {
+							"dataSource": {
+								"from": "//NetPrice/Amount|//Quantity",
+								"combinator": "multiply",
+								"fromOtherField": "LIST_PRICE",
+								"translation": "toDouble"
+							}
+						},
+						"translation": "toDouble"
+					}
+				},
+				{
+					"field": "CURRENCY",
+					"dataSource": {
+						"from": "//ListPrice/Currency",
+						"default": "USD"
+					}
+				},
+				{
+					"field": "ACCESS_PROVIDER",
+					"dataSource": {
+						"from": "//PurchaseOrder/VendorPOCode",
+						"translation": "lookupVendorId"
+					}
+				},
+				{
+					"field": "NOTE_FROM_VENDOR",
+					"dataSource": {
+						"from": "//PurchaseOrder/VendorCode"
+					}
+				},
+				{
+					"field": "OWNER",
+					"dataSource": {
+						"from": "//BaseAccount",
+						"default": "Main"
+					}
+				},
+				{
+					"field": "APPROVAL_STATUS",
+					"dataSource": {
+						"default": "APPROVED",
+						"translation": "lookupWorkflowStatusId",
+						"translateDefault": true
+					}
+				},
+				{
+					"field": "VENDOR",
+					"dataSource": {
+						"default": "GOBI Library Solutions"
+					}
+				},
+				{
+					"field": "ACTIVATION_STATUS",
+					"dataSource": {
+						"default": "NA",
+						"translation": "lookupActivationStatusId",
+						"translateDefault": true
+					}
+				},
+				{
+					"field": "CREATE_INVENTORY",
+					"dataSource": {
+						"default": true
+					}
+				},
+				{
+					"field": "TRIAL",
+					"dataSource": {
+						"default": false
+					}
+				},
+				{
+					"field": "FUND_PERCENTAGE",
+					"dataSource": {
+						"default": "100"
+					}
+				},
+				{
+					"field": "PRODUCT_ID_TYPE",
+					"dataSource": {
+						"default": "ISBN"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_FROM_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_INTERVAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_TO_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RECEIPT_DUE",
+					"dataSource": {
+						"default": true
+					}
+				},
+				{
+					"field": "ACQUISITION_METHOD",
+					"dataSource": {
+						"default": "Purchase at Vendor System"
+					}
+				},
+				{
+					"field": "CLAIM",
+					"dataSource": {
+						"default": "true"
+					}
+				},
+				{
+					"field": "COLLECTION",
+					"dataSource": {
+						"default": false
+					}
+				},
+				{
+					"field": "PO_LINE_WORKFLOW_STATUS",
+					"dataSource": {
+						"default": "Order Sent"
+					}
+				},
+				{
+					"field": "PO_LINE_RECEIPT_STATUS",
+					"dataSource": {
+						"default": "Receipt Not Required"
+					}
+				},
+				{
+					"field": "PO_LINE_PAYMENT_STATUS",
+					"dataSource": {
+						"default": "Awaiting Payment"
+					}
+				},
+				{
+					"field": "SOURCE_ID",
+					"dataSource": {
+						"default": "Loaded from Vendor (API)"
+					}
+				},
+				{
+					"field": "MANUAL_RENEWAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_CYCLE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_REVIEW_PERIOD",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_INTERVAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "VENDOR_REF_NO_TYPE",
+					"dataSource": {
+						"default": "Supplier's unique order line reference number"
+					}
+				}
+			]
+		},
+		{
+			"orderType": "ListedPrintSerial",
+			"mappings": [
+				{
+					"field": "TITLE",
+					"dataSource": {
+						"from": "//datafield[@tag='245']/*",
+						"combinator": "concat"
+					}
+				},
+				{
+					"field": "FUND_CODE",
+					"dataSource": {
+						"from": "//FundCode",
+						"translation": "lookupFundId"
+					}
+				},
+				{
+					"field": "INSTRUCTIONS",
+					"dataSource": {
+						"from": "//OrderNotes"
+					}
+				},
+				{
+					"field": "QUANTITY",
+					"dataSource": {
+						"from": "//Quantity",
+						"default": "1",
+						"translation": "toInteger"
+					}
+				},
+				{
+					"field": "VENDOR_REF_NO",
+					"dataSource": {
+						"from": "//YBPOrderKey"
+					}
+				},
+				{
+					"field": "CREATED_DATE",
+					"dataSource": {
+						"from": "//OrderPlaced",
+						"translation": "toDate"
+					}
+				},
+				{
+					"field": "OWNER",
+					"dataSource": {
+						"from": "//BaseAccount",
+						"default": "Main"
+					}
+				},
+				{
+					"field": "APPROVAL_STATUS",
+					"dataSource": {
+						"default": "APPROVED",
+						"translation": "lookupWorkflowStatusId",
+						"translateDefault": true
+					}
+				},
+				{
+					"field": "VENDOR",
+					"dataSource": {
+						"default": "GOBI Library Solutions"
+					}
+				},
+				{
+					"field": "FUND_PERCENTAGE",
+					"dataSource": {
+						"default": "100"
+					}
+				},
+				{
+					"field": "PRODUCT_ID_TYPE",
+					"dataSource": {
+						"default": "ISBN"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_FROM_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_INTERVAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "SUBSCRIPTION_TO_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RECEIPT_DUE",
+					"dataSource": {
+						"default": true
+					}
+				},
+				{
+					"field": "ACQUISITION_METHOD",
+					"dataSource": {
+						"default": "Purchase at Vendor System"
+					}
+				},
+				{
+					"field": "CLAIM",
+					"dataSource": {
+						"default": "true"
+					}
+				},
+				{
+					"field": "COLLECTION",
+					"dataSource": {
+						"default": false
+					}
+				},
+				{
+					"field": "PO_LINE_WORKFLOW_STATUS",
+					"dataSource": {
+						"default": "Order Sent"
+					}
+				},
+				{
+					"field": "PO_LINE_RECEIPT_STATUS",
+					"dataSource": {
+						"default": "Awaiting Receipt"
+					}
+				},
+				{
+					"field": "PO_LINE_PAYMENT_STATUS",
+					"dataSource": {
+						"default": "Awaiting Payment"
+					}
+				},
+				{
+					"field": "SOURCE_ID",
+					"dataSource": {
+						"default": "Loaded from Vendor (API)"
+					}
+				},
+				{
+					"field": "MANUAL_RENEWAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_CYCLE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_DATE",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_REVIEW_PERIOD",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "RENEWAL_INTERVAL",
+					"dataSource": {
+						"default": "NA"
+					}
+				},
+				{
+					"field": "VENDOR_REF_NO_TYPE",
+					"dataSource": {
+						"default": "Supplier's unique order line reference number"
+					}
+				}
+			]
+		}
   ]
 }

--- a/src/main/resources/data-mapping.json
+++ b/src/main/resources/data-mapping.json
@@ -720,622 +720,622 @@
       ]
     },
     {
-			"orderType": "ListedPrintSerial",
-			"mappings": [
-				{
-					"field": "TITLE",
-					"dataSource": {
-						"from": "//datafield[@tag='245']/*",
-						"combinator": "concat"
-					}
-				},
-				{
-					"field": "PUBLISHER",
-					"dataSource": {
-						"from": "//datafield[@tag='260']/subfield[@code='b']"
-					}
-				},
-				{
-					"field": "FUND_CODE",
-					"dataSource": {
-						"from": "//FundCode",
-						"translation": "lookupFundId"
-					}
-				},
-				{
-					"field": "INSTRUCTIONS",
-					"dataSource": {
-						"from": "//OrderNotes"
-					}
-				},
-				{
-					"field": "QUANTITY",
-					"dataSource": {
-						"from": "//Quantity",
-						"default": "1",
-						"translation": "toInteger"
-					}
-				},
-				{
-					"field": "VENDOR_REF_NO",
-					"dataSource": {
-						"from": "//YBPOrderKey"
-					}
-				},
-				{
-					"field": "CREATED_DATE",
-					"dataSource": {
-						"from": "//OrderPlaced",
-						"translation": "toDate"
-					}
-				},
-				{
-					"field": "OWNER",
-					"dataSource": {
-						"from": "//BaseAccount",
-						"default": "Main"
-					}
-				},
-				{
-					"field": "APPROVAL_STATUS",
-					"dataSource": {
-						"default": "APPROVED",
-						"translation": "lookupWorkflowStatusId",
-						"translateDefault": true
-					}
-				},
-				{
-					"field": "VENDOR",
-					"dataSource": {
-						"default": "GOBI Library Solutions"
-					}
-				},
-				{
-					"field": "FUND_PERCENTAGE",
-					"dataSource": {
-						"default": "100"
-					}
-				},
-				{
-					"field": "PRODUCT_ID_TYPE",
-					"dataSource": {
-						"default": "ISBN"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_FROM_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_INTERVAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_TO_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RECEIPT_DUE",
-					"dataSource": {
-						"default": true
-					}
-				},
-				{
-					"field": "ACQUISITION_METHOD",
-					"dataSource": {
-						"default": "Purchase at Vendor System"
-					}
-				},
-				{
-					"field": "CLAIM",
-					"dataSource": {
-						"default": "true"
-					}
-				},
-				{
-					"field": "COLLECTION",
-					"dataSource": {
-						"default": false
-					}
-				},
-				{
-					"field": "PO_LINE_WORKFLOW_STATUS",
-					"dataSource": {
-						"default": "Order Sent"
-					}
-				},
-				{
-					"field": "PO_LINE_RECEIPT_STATUS",
-					"dataSource": {
-						"default": "Awaiting Receipt"
-					}
-				},
-				{
-					"field": "PO_LINE_PAYMENT_STATUS",
-					"dataSource": {
-						"default": "Awaiting Payment"
-					}
-				},
-				{
-					"field": "SOURCE_ID",
-					"dataSource": {
-						"default": "Loaded from Vendor (API)"
-					}
-				},
-				{
-					"field": "MANUAL_RENEWAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_CYCLE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_REVIEW_PERIOD",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_INTERVAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "VENDOR_REF_NO_TYPE",
-					"dataSource": {
-						"default": "Supplier's unique order line reference number"
-					}
-				}
-			]
-		},
-		{
-			"orderType": "ListedElectronicSerial",
-			"mappings": [
-				{
-					"field": "TITLE",
-					"dataSource": {
-						"from": "//datafield[@tag='245']/*",
-						"combinator": "concat"
-					}
-				},
-				{
-					"field": "PUBLISHER",
-					"dataSource": {
-						"from": "//datafield[@tag='260']/subfield[@code='b']"
-					}
-				},
-				{
-					"field": "FUND_CODE",
-					"dataSource": {
-						"from": "//FundCode",
-						"translation": "lookupFundId"
-					}
-				},
-				{
-					"field": "INSTRUCTIONS",
-					"dataSource": {
-						"from": "//OrderNotes"
-					}
-				},
-				{
-					"field": "QUANTITY",
-					"dataSource": {
-						"from": "//Quantity",
-						"default": "1",
-						"translation": "toInteger"
-					}
-				},
-				{
-					"field": "VENDOR_REF_NO",
-					"dataSource": {
-						"from": "//YBPOrderKey"
-					}
-				},
-				{
-					"field": "CREATED_DATE",
-					"dataSource": {
-						"from": "//OrderPlaced",
-						"translation": "toDate"
-					}
-				},
-				{
-					"field": "LIST_PRICE",
-					"dataSource": {
-						"from": "//ListPrice/Amount",
-						"default": "0",
-						"translation": "toDouble"
-					}
-				},
-				{
-					"field": "ESTIMATED_PRICE",
-					"dataSource": {
-						"from": "//ListPrice/Amount",
-						"defaultMapping": {
-							"dataSource": {
-								"from": "//NetPrice/Amount|//Quantity",
-								"combinator": "multiply",
-								"fromOtherField": "LIST_PRICE",
-								"translation": "toDouble"
-							}
-						},
-						"translation": "toDouble"
-					}
-				},
-				{
-					"field": "CURRENCY",
-					"dataSource": {
-						"from": "//ListPrice/Currency",
-						"default": "USD"
-					}
-				},
-				{
-					"field": "ACCESS_PROVIDER",
-					"dataSource": {
-						"from": "//PurchaseOrder/VendorPOCode",
-						"translation": "lookupVendorId"
-					}
-				},
-				{
-					"field": "NOTE_FROM_VENDOR",
-					"dataSource": {
-						"from": "//PurchaseOrder/VendorCode"
-					}
-				},
-				{
-					"field": "OWNER",
-					"dataSource": {
-						"from": "//BaseAccount",
-						"default": "Main"
-					}
-				},
-				{
-					"field": "APPROVAL_STATUS",
-					"dataSource": {
-						"default": "APPROVED",
-						"translation": "lookupWorkflowStatusId",
-						"translateDefault": true
-					}
-				},
-				{
-					"field": "VENDOR",
-					"dataSource": {
-						"default": "GOBI Library Solutions"
-					}
-				},
-				{
-					"field": "ACTIVATION_STATUS",
-					"dataSource": {
-						"default": "NA",
-						"translation": "lookupActivationStatusId",
-						"translateDefault": true
-					}
-				},
-				{
-					"field": "CREATE_INVENTORY",
-					"dataSource": {
-						"default": true
-					}
-				},
-				{
-					"field": "TRIAL",
-					"dataSource": {
-						"default": false
-					}
-				},
-				{
-					"field": "FUND_PERCENTAGE",
-					"dataSource": {
-						"default": "100"
-					}
-				},
-				{
-					"field": "PRODUCT_ID_TYPE",
-					"dataSource": {
-						"default": "ISBN"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_FROM_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_INTERVAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_TO_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RECEIPT_DUE",
-					"dataSource": {
-						"default": true
-					}
-				},
-				{
-					"field": "ACQUISITION_METHOD",
-					"dataSource": {
-						"default": "Purchase at Vendor System"
-					}
-				},
-				{
-					"field": "CLAIM",
-					"dataSource": {
-						"default": "true"
-					}
-				},
-				{
-					"field": "COLLECTION",
-					"dataSource": {
-						"default": false
-					}
-				},
-				{
-					"field": "PO_LINE_WORKFLOW_STATUS",
-					"dataSource": {
-						"default": "Order Sent"
-					}
-				},
-				{
-					"field": "PO_LINE_RECEIPT_STATUS",
-					"dataSource": {
-						"default": "Receipt Not Required"
-					}
-				},
-				{
-					"field": "PO_LINE_PAYMENT_STATUS",
-					"dataSource": {
-						"default": "Awaiting Payment"
-					}
-				},
-				{
-					"field": "SOURCE_ID",
-					"dataSource": {
-						"default": "Loaded from Vendor (API)"
-					}
-				},
-				{
-					"field": "MANUAL_RENEWAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_CYCLE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_REVIEW_PERIOD",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_INTERVAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "VENDOR_REF_NO_TYPE",
-					"dataSource": {
-						"default": "Supplier's unique order line reference number"
-					}
-				}
-			]
-		},
-		{
-			"orderType": "ListedPrintSerial",
-			"mappings": [
-				{
-					"field": "TITLE",
-					"dataSource": {
-						"from": "//datafield[@tag='245']/*",
-						"combinator": "concat"
-					}
-				},
-				{
-					"field": "FUND_CODE",
-					"dataSource": {
-						"from": "//FundCode",
-						"translation": "lookupFundId"
-					}
-				},
-				{
-					"field": "INSTRUCTIONS",
-					"dataSource": {
-						"from": "//OrderNotes"
-					}
-				},
-				{
-					"field": "QUANTITY",
-					"dataSource": {
-						"from": "//Quantity",
-						"default": "1",
-						"translation": "toInteger"
-					}
-				},
-				{
-					"field": "VENDOR_REF_NO",
-					"dataSource": {
-						"from": "//YBPOrderKey"
-					}
-				},
-				{
-					"field": "CREATED_DATE",
-					"dataSource": {
-						"from": "//OrderPlaced",
-						"translation": "toDate"
-					}
-				},
-				{
-					"field": "OWNER",
-					"dataSource": {
-						"from": "//BaseAccount",
-						"default": "Main"
-					}
-				},
-				{
-					"field": "APPROVAL_STATUS",
-					"dataSource": {
-						"default": "APPROVED",
-						"translation": "lookupWorkflowStatusId",
-						"translateDefault": true
-					}
-				},
-				{
-					"field": "VENDOR",
-					"dataSource": {
-						"default": "GOBI Library Solutions"
-					}
-				},
-				{
-					"field": "FUND_PERCENTAGE",
-					"dataSource": {
-						"default": "100"
-					}
-				},
-				{
-					"field": "PRODUCT_ID_TYPE",
-					"dataSource": {
-						"default": "ISBN"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_FROM_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_INTERVAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "SUBSCRIPTION_TO_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RECEIPT_DUE",
-					"dataSource": {
-						"default": true
-					}
-				},
-				{
-					"field": "ACQUISITION_METHOD",
-					"dataSource": {
-						"default": "Purchase at Vendor System"
-					}
-				},
-				{
-					"field": "CLAIM",
-					"dataSource": {
-						"default": "true"
-					}
-				},
-				{
-					"field": "COLLECTION",
-					"dataSource": {
-						"default": false
-					}
-				},
-				{
-					"field": "PO_LINE_WORKFLOW_STATUS",
-					"dataSource": {
-						"default": "Order Sent"
-					}
-				},
-				{
-					"field": "PO_LINE_RECEIPT_STATUS",
-					"dataSource": {
-						"default": "Awaiting Receipt"
-					}
-				},
-				{
-					"field": "PO_LINE_PAYMENT_STATUS",
-					"dataSource": {
-						"default": "Awaiting Payment"
-					}
-				},
-				{
-					"field": "SOURCE_ID",
-					"dataSource": {
-						"default": "Loaded from Vendor (API)"
-					}
-				},
-				{
-					"field": "MANUAL_RENEWAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_CYCLE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_DATE",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_REVIEW_PERIOD",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "RENEWAL_INTERVAL",
-					"dataSource": {
-						"default": "NA"
-					}
-				},
-				{
-					"field": "VENDOR_REF_NO_TYPE",
-					"dataSource": {
-						"default": "Supplier's unique order line reference number"
-					}
-				}
-			]
-		}
+      "orderType": "ListedPrintSerial",
+      "mappings": [
+        {
+          "field": "TITLE",
+          "dataSource": {
+            "from": "//datafield[@tag='245']/*",
+            "combinator": "concat"
+          }
+        },
+        {
+          "field": "PUBLISHER",
+          "dataSource": {
+            "from": "//datafield[@tag='260']/subfield[@code='b']"
+          }
+        },
+        {
+          "field": "FUND_CODE",
+          "dataSource": {
+            "from": "//FundCode",
+            "translation": "lookupFundId"
+          }
+        },
+        {
+          "field": "INSTRUCTIONS",
+          "dataSource": {
+            "from": "//OrderNotes"
+          }
+        },
+        {
+          "field": "QUANTITY",
+          "dataSource": {
+            "from": "//Quantity",
+            "default": "1",
+            "translation": "toInteger"
+          }
+        },
+        {
+          "field": "VENDOR_REF_NO",
+          "dataSource": {
+            "from": "//YBPOrderKey"
+          }
+        },
+        {
+          "field": "CREATED_DATE",
+          "dataSource": {
+            "from": "//OrderPlaced",
+            "translation": "toDate"
+          }
+        },
+        {
+          "field": "OWNER",
+          "dataSource": {
+            "from": "//BaseAccount",
+            "default": "Main"
+          }
+        },
+        {
+          "field": "APPROVAL_STATUS",
+          "dataSource": {
+            "default": "APPROVED",
+            "translation": "lookupWorkflowStatusId",
+            "translateDefault": true
+          }
+        },
+        {
+          "field": "VENDOR",
+          "dataSource": {
+            "default": "GOBI Library Solutions"
+          }
+        },
+        {
+          "field": "FUND_PERCENTAGE",
+          "dataSource": {
+            "default": "100"
+          }
+        },
+        {
+          "field": "PRODUCT_ID_TYPE",
+          "dataSource": {
+            "default": "ISBN"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_FROM_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_INTERVAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_TO_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RECEIPT_DUE",
+          "dataSource": {
+            "default": true
+          }
+        },
+        {
+          "field": "ACQUISITION_METHOD",
+          "dataSource": {
+            "default": "Purchase at Vendor System"
+          }
+        },
+        {
+          "field": "CLAIM",
+          "dataSource": {
+            "default": "true"
+          }
+        },
+        {
+          "field": "COLLECTION",
+          "dataSource": {
+            "default": false
+          }
+        },
+        {
+          "field": "PO_LINE_WORKFLOW_STATUS",
+          "dataSource": {
+            "default": "Order Sent"
+          }
+        },
+        {
+          "field": "PO_LINE_RECEIPT_STATUS",
+          "dataSource": {
+            "default": "Awaiting Receipt"
+          }
+        },
+        {
+          "field": "PO_LINE_PAYMENT_STATUS",
+          "dataSource": {
+            "default": "Awaiting Payment"
+          }
+        },
+        {
+          "field": "SOURCE_ID",
+          "dataSource": {
+            "default": "Loaded from Vendor (API)"
+          }
+        },
+        {
+          "field": "MANUAL_RENEWAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_CYCLE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_REVIEW_PERIOD",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_INTERVAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "VENDOR_REF_NO_TYPE",
+          "dataSource": {
+            "default": "Supplier's unique order line reference number"
+          }
+        }
+      ]
+    },
+    {
+      "orderType": "ListedElectronicSerial",
+      "mappings": [
+        {
+          "field": "TITLE",
+          "dataSource": {
+            "from": "//datafield[@tag='245']/*",
+            "combinator": "concat"
+          }
+        },
+        {
+          "field": "PUBLISHER",
+          "dataSource": {
+            "from": "//datafield[@tag='260']/subfield[@code='b']"
+          }
+        },
+        {
+          "field": "FUND_CODE",
+          "dataSource": {
+            "from": "//FundCode",
+            "translation": "lookupFundId"
+          }
+        },
+        {
+          "field": "INSTRUCTIONS",
+          "dataSource": {
+            "from": "//OrderNotes"
+          }
+        },
+        {
+          "field": "QUANTITY",
+          "dataSource": {
+            "from": "//Quantity",
+            "default": "1",
+            "translation": "toInteger"
+          }
+        },
+        {
+          "field": "VENDOR_REF_NO",
+          "dataSource": {
+            "from": "//YBPOrderKey"
+          }
+        },
+        {
+          "field": "CREATED_DATE",
+          "dataSource": {
+            "from": "//OrderPlaced",
+            "translation": "toDate"
+          }
+        },
+        {
+          "field": "LIST_PRICE",
+          "dataSource": {
+            "from": "//ListPrice/Amount",
+            "default": "0",
+            "translation": "toDouble"
+          }
+        },
+        {
+          "field": "ESTIMATED_PRICE",
+          "dataSource": {
+            "from": "//ListPrice/Amount",
+            "defaultMapping": {
+              "dataSource": {
+                "from": "//NetPrice/Amount|//Quantity",
+                "combinator": "multiply",
+                "fromOtherField": "LIST_PRICE",
+                "translation": "toDouble"
+              }
+            },
+            "translation": "toDouble"
+          }
+        },
+        {
+          "field": "CURRENCY",
+          "dataSource": {
+            "from": "//ListPrice/Currency",
+            "default": "USD"
+          }
+        },
+        {
+          "field": "ACCESS_PROVIDER",
+          "dataSource": {
+            "from": "//PurchaseOrder/VendorPOCode",
+            "translation": "lookupVendorId"
+          }
+        },
+        {
+          "field": "NOTE_FROM_VENDOR",
+          "dataSource": {
+            "from": "//PurchaseOrder/VendorCode"
+          }
+        },
+        {
+          "field": "OWNER",
+          "dataSource": {
+            "from": "//BaseAccount",
+            "default": "Main"
+          }
+        },
+        {
+          "field": "APPROVAL_STATUS",
+          "dataSource": {
+            "default": "APPROVED",
+            "translation": "lookupWorkflowStatusId",
+            "translateDefault": true
+          }
+        },
+        {
+          "field": "VENDOR",
+          "dataSource": {
+            "default": "GOBI Library Solutions"
+          }
+        },
+        {
+          "field": "ACTIVATION_STATUS",
+          "dataSource": {
+            "default": "NA",
+            "translation": "lookupActivationStatusId",
+            "translateDefault": true
+          }
+        },
+        {
+          "field": "CREATE_INVENTORY",
+          "dataSource": {
+            "default": true
+          }
+        },
+        {
+          "field": "TRIAL",
+          "dataSource": {
+            "default": false
+          }
+        },
+        {
+          "field": "FUND_PERCENTAGE",
+          "dataSource": {
+            "default": "100"
+          }
+        },
+        {
+          "field": "PRODUCT_ID_TYPE",
+          "dataSource": {
+            "default": "ISBN"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_FROM_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_INTERVAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_TO_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RECEIPT_DUE",
+          "dataSource": {
+            "default": true
+          }
+        },
+        {
+          "field": "ACQUISITION_METHOD",
+          "dataSource": {
+            "default": "Purchase at Vendor System"
+          }
+        },
+        {
+          "field": "CLAIM",
+          "dataSource": {
+            "default": "true"
+          }
+        },
+        {
+          "field": "COLLECTION",
+          "dataSource": {
+            "default": false
+          }
+        },
+        {
+          "field": "PO_LINE_WORKFLOW_STATUS",
+          "dataSource": {
+            "default": "Order Sent"
+          }
+        },
+        {
+          "field": "PO_LINE_RECEIPT_STATUS",
+          "dataSource": {
+            "default": "Receipt Not Required"
+          }
+        },
+        {
+          "field": "PO_LINE_PAYMENT_STATUS",
+          "dataSource": {
+            "default": "Awaiting Payment"
+          }
+        },
+        {
+          "field": "SOURCE_ID",
+          "dataSource": {
+            "default": "Loaded from Vendor (API)"
+          }
+        },
+        {
+          "field": "MANUAL_RENEWAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_CYCLE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_REVIEW_PERIOD",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_INTERVAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "VENDOR_REF_NO_TYPE",
+          "dataSource": {
+            "default": "Supplier's unique order line reference number"
+          }
+        }
+      ]
+    },
+    {
+      "orderType": "UnlistedPrintSerial",
+      "mappings": [
+        {
+          "field": "TITLE",
+          "dataSource": {
+            "from": "//datafield[@tag='245']/*",
+            "combinator": "concat"
+          }
+        },
+        {
+          "field": "FUND_CODE",
+          "dataSource": {
+            "from": "//FundCode",
+            "translation": "lookupFundId"
+          }
+        },
+        {
+          "field": "INSTRUCTIONS",
+          "dataSource": {
+            "from": "//OrderNotes"
+          }
+        },
+        {
+          "field": "QUANTITY",
+          "dataSource": {
+            "from": "//Quantity",
+            "default": "1",
+            "translation": "toInteger"
+          }
+        },
+        {
+          "field": "VENDOR_REF_NO",
+          "dataSource": {
+            "from": "//YBPOrderKey"
+          }
+        },
+        {
+          "field": "CREATED_DATE",
+          "dataSource": {
+            "from": "//OrderPlaced",
+            "translation": "toDate"
+          }
+        },
+        {
+          "field": "OWNER",
+          "dataSource": {
+            "from": "//BaseAccount",
+            "default": "Main"
+          }
+        },
+        {
+          "field": "APPROVAL_STATUS",
+          "dataSource": {
+            "default": "APPROVED",
+            "translation": "lookupWorkflowStatusId",
+            "translateDefault": true
+          }
+        },
+        {
+          "field": "VENDOR",
+          "dataSource": {
+            "default": "GOBI Library Solutions"
+          }
+        },
+        {
+          "field": "FUND_PERCENTAGE",
+          "dataSource": {
+            "default": "100"
+          }
+        },
+        {
+          "field": "PRODUCT_ID_TYPE",
+          "dataSource": {
+            "default": "ISBN"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_FROM_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_INTERVAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "SUBSCRIPTION_TO_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RECEIPT_DUE",
+          "dataSource": {
+            "default": true
+          }
+        },
+        {
+          "field": "ACQUISITION_METHOD",
+          "dataSource": {
+            "default": "Purchase at Vendor System"
+          }
+        },
+        {
+          "field": "CLAIM",
+          "dataSource": {
+            "default": "true"
+          }
+        },
+        {
+          "field": "COLLECTION",
+          "dataSource": {
+            "default": false
+          }
+        },
+        {
+          "field": "PO_LINE_WORKFLOW_STATUS",
+          "dataSource": {
+            "default": "Order Sent"
+          }
+        },
+        {
+          "field": "PO_LINE_RECEIPT_STATUS",
+          "dataSource": {
+            "default": "Awaiting Receipt"
+          }
+        },
+        {
+          "field": "PO_LINE_PAYMENT_STATUS",
+          "dataSource": {
+            "default": "Awaiting Payment"
+          }
+        },
+        {
+          "field": "SOURCE_ID",
+          "dataSource": {
+            "default": "Loaded from Vendor (API)"
+          }
+        },
+        {
+          "field": "MANUAL_RENEWAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_CYCLE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_DATE",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_REVIEW_PERIOD",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "RENEWAL_INTERVAL",
+          "dataSource": {
+            "default": "NA"
+          }
+        },
+        {
+          "field": "VENDOR_REF_NO_TYPE",
+          "dataSource": {
+            "default": "Supplier's unique order line reference number"
+          }
+        }
+      ]
+    }
   ]
 }

--- a/src/main/resources/data-mapping.json
+++ b/src/main/resources/data-mapping.json
@@ -684,7 +684,7 @@
         {
           "field": "NOTE_FROM_VENDOR",
           "dataSource": {
-            "from": "//PurchaseOrder/VendorCode"
+            "from": "//PurchaseOption/VendorCode"
           }
         },
         {
@@ -936,7 +936,7 @@
         {
           "field": "NOTE_FROM_VENDOR",
           "dataSource": {
-            "from": "//PurchaseOrder/VendorCode"
+            "from": "//PurchaseOption/VendorCode"
           }
         },
         {

--- a/src/main/resources/data-mapping.json
+++ b/src/main/resources/data-mapping.json
@@ -719,7 +719,7 @@
         }
       ]
     },
-    {
+   {
       "orderType": "ListedPrintSerial",
       "mappings": [
         {
@@ -803,24 +803,6 @@
           }
         },
         {
-          "field": "SUBSCRIPTION_FROM_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "SUBSCRIPTION_INTERVAL",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "SUBSCRIPTION_TO_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
           "field": "RECEIPT_DUE",
           "dataSource": {
             "default": true
@@ -866,36 +848,6 @@
           "field": "SOURCE_ID",
           "dataSource": {
             "default": "Loaded from Vendor (API)"
-          }
-        },
-        {
-          "field": "MANUAL_RENEWAL",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_CYCLE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_REVIEW_PERIOD",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_INTERVAL",
-          "dataSource": {
-            "default": "NA"
           }
         },
         {
@@ -1021,14 +973,6 @@
           }
         },
         {
-          "field": "ACTIVATION_STATUS",
-          "dataSource": {
-            "default": "NA",
-            "translation": "lookupActivationStatusId",
-            "translateDefault": true
-          }
-        },
-        {
           "field": "CREATE_INVENTORY",
           "dataSource": {
             "default": true
@@ -1050,30 +994,6 @@
           "field": "PRODUCT_ID_TYPE",
           "dataSource": {
             "default": "ISBN"
-          }
-        },
-        {
-          "field": "SUBSCRIPTION_FROM_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "SUBSCRIPTION_INTERVAL",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "SUBSCRIPTION_TO_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RECEIPT_DUE",
-          "dataSource": {
-            "default": true
           }
         },
         {
@@ -1116,36 +1036,6 @@
           "field": "SOURCE_ID",
           "dataSource": {
             "default": "Loaded from Vendor (API)"
-          }
-        },
-        {
-          "field": "MANUAL_RENEWAL",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_CYCLE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_REVIEW_PERIOD",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_INTERVAL",
-          "dataSource": {
-            "default": "NA"
           }
         },
         {
@@ -1234,24 +1124,6 @@
           }
         },
         {
-          "field": "SUBSCRIPTION_FROM_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "SUBSCRIPTION_INTERVAL",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "SUBSCRIPTION_TO_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
           "field": "RECEIPT_DUE",
           "dataSource": {
             "default": true
@@ -1297,36 +1169,6 @@
           "field": "SOURCE_ID",
           "dataSource": {
             "default": "Loaded from Vendor (API)"
-          }
-        },
-        {
-          "field": "MANUAL_RENEWAL",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_CYCLE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_DATE",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_REVIEW_PERIOD",
-          "dataSource": {
-            "default": "NA"
-          }
-        },
-        {
-          "field": "RENEWAL_INTERVAL",
-          "dataSource": {
-            "default": "NA"
           }
         },
         {

--- a/src/main/resources/data-mapping.json
+++ b/src/main/resources/data-mapping.json
@@ -843,18 +843,6 @@
           "dataSource": {
             "default": "Awaiting Payment"
           }
-        },
-        {
-          "field": "SOURCE_ID",
-          "dataSource": {
-            "default": "Loaded from Vendor (API)"
-          }
-        },
-        {
-          "field": "VENDOR_REF_NO_TYPE",
-          "dataSource": {
-            "default": "Supplier's unique order line reference number"
-          }
         }
       ]
     },
@@ -1031,18 +1019,6 @@
           "dataSource": {
             "default": "Awaiting Payment"
           }
-        },
-        {
-          "field": "SOURCE_ID",
-          "dataSource": {
-            "default": "Loaded from Vendor (API)"
-          }
-        },
-        {
-          "field": "VENDOR_REF_NO_TYPE",
-          "dataSource": {
-            "default": "Supplier's unique order line reference number"
-          }
         }
       ]
     },
@@ -1163,18 +1139,6 @@
           "field": "PO_LINE_PAYMENT_STATUS",
           "dataSource": {
             "default": "Awaiting Payment"
-          }
-        },
-        {
-          "field": "SOURCE_ID",
-          "dataSource": {
-            "default": "Loaded from Vendor (API)"
-          }
-        },
-        {
-          "field": "VENDOR_REF_NO_TYPE",
-          "dataSource": {
-            "default": "Supplier's unique order line reference number"
           }
         }
       ]

--- a/src/main/resources/data-mapping.json
+++ b/src/main/resources/data-mapping.json
@@ -677,7 +677,7 @@
         {
           "field": "ACCESS_PROVIDER",
           "dataSource": {
-            "from": "//PurchaseOrder/VendorPOCode",
+            "from": "//PurchaseOption/VendorPOCode",
             "translation": "lookupVendorId"
           }
         },
@@ -941,7 +941,7 @@
         {
           "field": "ACCESS_PROVIDER",
           "dataSource": {
-            "from": "//PurchaseOrder/VendorPOCode",
+            "from": "//PurchaseOption/VendorPOCode",
             "translation": "lookupVendorId"
           }
         },


### PR DESCRIPTION
I will get a US created for the fields I could not map. 
There are few other fields on which a decision is pending on the details of what the default values must be ex: renewal_interval , renewal_cycle etc.. 