### PR TITLE
Update locations interface version to add 3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 1.0.1 Unreleased
- * Requires `locations` interface 2.0 or 3.0
+ * Requires `locations` interface 2.1 or 3.0
  * [MODGOBI-28](https://issues.folio.org/browse/MODGOBI-28)
  * [MODGOBI-27](https://issues.folio.org/browse/MODGOBI-27)
  * [MODGOBI-26](https://issues.folio.org/browse/MODGOBI-26)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 1.0.1 Unreleased
+ * Requires `locations` interface 2.0 or 3.0
  * [MODGOBI-28](https://issues.folio.org/browse/MODGOBI-28)
  * [MODGOBI-27](https://issues.folio.org/browse/MODGOBI-27)
  * [MODGOBI-26](https://issues.folio.org/browse/MODGOBI-26)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -41,7 +41,7 @@
     },
     {
       "id": "locations",
-      "version": "2.1"
+      "version": "2.1 3.0"
     },
     {
       "id": "vendor",


### PR DESCRIPTION
Enabling Mod-inventory-storage for a tenant is causing an error due to the locations interface upgrade

`Incompatible version for module mod-gobi-1.0.1-SNAPSHOT.64 interface locations. Need 2.1. Have 3.0`