### PR TITLE
MODGOBI-46 : po_lines property is renamed to compositePoLines

### DIFF
--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -548,14 +548,6 @@ public class Mapper {
                   CompositePoLine.ReceiptStatus.fromValue((String) o)))
               .exceptionally(Mapper::logException));
     }
-    if (mappings.containsKey(Mapping.Field.PO_LINE_WORKFLOW_STATUS)) {
-      futures
-          .add(mappings.get(Mapping.Field.PO_LINE_WORKFLOW_STATUS)
-          .resolve(doc)
-          .thenAccept(o -> CompositePurchaseOrder.WorkflowStatus.fromValue((String) o))
-          .exceptionally(Mapper::logException));
-    }
-
   }
 
   private void mapCost(List<CompletableFuture<?>> futures, Cost cost,Document doc) {

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -130,7 +130,7 @@ public class Mapper {
             });
             poLines.add(pol);
 
-            compPO.setPoLines(poLines);
+            compPO.setCompositePoLines(poLines);
             future.complete(compPO);
           });
     } catch (Exception e) {
@@ -552,8 +552,7 @@ public class Mapper {
       futures
           .add(mappings.get(Mapping.Field.PO_LINE_WORKFLOW_STATUS)
           .resolve(doc)
-          .thenAccept(o -> pol.setPoLineWorkflowStatus(
-                  CompositePoLine.PoLineWorkflowStatus.fromValue((String) o)))
+          .thenAccept(o -> CompositePurchaseOrder.WorkflowStatus.fromValue((String) o))
           .exceptionally(Mapper::logException));
     }
 

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -278,7 +278,7 @@ public class PostGobiOrdersHelper {
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenAccept(body -> {
           logger.info("Response from mod-orders: " + body.encodePrettily());
-          future.complete(body.getJsonArray("po_lines").getJsonObject(0).getString("po_line_number"));
+          future.complete(body.getJsonArray("compositePoLines").getJsonObject(0).getString("po_line_number"));
         })
         .exceptionally(t -> {
           future.completeExceptionally(t);

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -494,7 +494,7 @@ public class GOBIIntegrationServiceResourceImplTest {
       compPO.put("id", UUID.randomUUID().toString());
       String poNumber = "PO_" + randomDigits(10);
       compPO.put("po_number", poNumber);
-      compPO.getJsonArray("po_lines").forEach(line -> {
+      compPO.getJsonArray("compositePoLines").forEach(line -> {
         JsonObject poLine = (JsonObject) line;
         poLine.put("id", UUID.randomUUID().toString());
         poLine.put("po_line_number", poNumber + "-1");


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODGOBI-43 Move "Renewals" information to Purchase Order level

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODGOBI-43
 -->
https://issues.folio.org/browse/MODGOBI-46

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

- Change all occurrences of `po_line` to `compositePoLines`
- Update tests to handle the change

For testing purpose, I made changes to `acq-models/composite_purchase_order.json` and `acq-models/examples/composite_purchase_order.sample` locally and build is a success locally. This branch will fail in Jenkins until https://github.com/folio-org/acq-models/pull/48 is merged. 
