### PR TITLE
MODORDERS-142 updated composite PO field "po_lines" to "compositePoLines"

### DIFF
--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -130,7 +130,7 @@ public class Mapper {
             });
             poLines.add(pol);
 
-            compPO.setPoLines(poLines);
+            compPO.setCompositePoLines(poLines);
             future.complete(compPO);
           });
     } catch (Exception e) {

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -276,7 +276,7 @@ public class PostGobiOrdersHelper {
         .thenApply(HelperUtils::verifyAndExtractBody)
         .thenAccept(body -> {
           logger.info("Response from mod-orders: " + body.encodePrettily());
-          future.complete(body.getJsonArray("po_lines").getJsonObject(0).getString("po_line_number"));
+          future.complete(body.getJsonArray("compositePoLines").getJsonObject(0).getString("po_line_number"));
         })
         .exceptionally(t -> {
           future.completeExceptionally(t);

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -523,7 +523,7 @@ public class GOBIIntegrationServiceResourceImplTest {
       compPO.put("id", UUID.randomUUID().toString());
       String poNumber = "PO_" + randomDigits(10);
       compPO.put("po_number", poNumber);
-      compPO.getJsonArray("po_lines").forEach(line -> {
+      compPO.getJsonArray("compositePoLines").forEach(line -> {
         JsonObject poLine = (JsonObject) line;
         poLine.put("id", UUID.randomUUID().toString());
         poLine.put("po_line_number", poNumber + "-1");


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDERS-142
Because of changing composite PO field "po_lines" to "compositePoLines" mod-gobi module updates needed

## Approach
* updating acq-models as submodule
* The code and unit tests are fixed according schema changes

#### TODOS and Open Questions
Be sure https://github.com/folio-org/acq-models/pull/48 and  https://github.com/folio-org/mod-orders/pull/91 merged firstly