### PR TITLE
MODGOBI- Use default location only if not specified

### DIFF
--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -75,7 +75,6 @@ public class Mapper {
 
             setObjectIfPresent(adjustment, o -> compPO.setAdjustment((Adjustment) o));
             setObjectIfPresent(detail, o -> pol.setDetails((Details) o));
-            setObjectIfPresent(detail, o -> pol.setDetails((Details) o));
             setObjectIfPresent(cost, o -> pol.setCost((Cost) o));
             setObjectIfPresent(eresource, o -> pol.setEresource((Eresource) o));
             setObjectIfPresent(vendorDetail, o -> pol.setVendorDetail((VendorDetail) o));

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -71,9 +71,6 @@ public class Mapper {
 
       CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[futures.size()]))
           .thenAccept(v -> {
-            List<ProductId> ids = new ArrayList<>();
-            ids.add(productId);
-            detail.setProductIds(ids);
             compPO.setTotalItems(location.getQuantity());
 
             setObjectIfPresent(adjustment, o -> compPO.setAdjustment((Adjustment) o));
@@ -523,7 +520,12 @@ public class Mapper {
               Optional.ofNullable(mappings.get(Mapping.Field.PRODUCT_ID_TYPE))
                   .ifPresent(prodidtype -> prodidtype.resolve(doc)
                       .thenAccept(
-                          idType -> productId.setProductIdType(ProductId.ProductIdType.fromValue((String) idType))));
+                          idType -> {
+                              productId.setProductIdType(ProductId.ProductIdType.fromValue((String) idType));
+                              List<ProductId> ids = new ArrayList<>();
+                              ids.add(productId);
+                              detail.setProductIds(ids);
+                          }));
             })
             .exceptionally(Mapper::logException)));
 

--- a/src/main/java/org/folio/gobi/MappingHelper.java
+++ b/src/main/java/org/folio/gobi/MappingHelper.java
@@ -120,6 +120,9 @@ public class MappingHelper {
           case LOOKUP_LOCATION_ID:
             translatedValue = postGobiOrdersHelper.lookupLocationId(data);
             break;
+          case LOOKUP_DEFAULT_LOCATION_ID:
+              translatedValue = postGobiOrdersHelper.lookupDefaultLocationId(data);
+              break;
           case LOOKUP_MATERIAL_TYPE_ID:
             translatedValue = postGobiOrdersHelper.lookupMaterialTypeId(data);
             break;

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -7,7 +7,8 @@ import static org.folio.rest.jaxrs.resource.Gobi.PostGobiOrdersResponse.respond4
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import org.apache.commons.lang.StringUtils;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
@@ -61,6 +62,7 @@ public class PostGobiOrdersHelper {
   public static final String CQL_CODE_STRING_FMT = "code==\"%s\"";
   public static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String EXCEPTION_CALLING_ENDPOINT_MSG = "Exception calling {} {}";
+  private static final String DEFAULT_LOCATION_CODE = "*";
 
   private final HttpClientInterface httpClient;
   private final Context ctx;
@@ -167,8 +169,26 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupLocationId(String location) {
     logger.info("Received location is {}", location);
+    String query = HelperUtils.encodeValue(String.format(CQL_CODE_STRING_FMT, location), logger);
+    String endpoint = String.format(LOCATIONS_ENDPOINT + QUERY, query);
+    return handleGetRequest(endpoint)
+        .thenCompose(locations -> {
+              String locationId = HelperUtils.extractLocationId(locations);
+               if (StringUtils.isEmpty(locationId)) {
+        	   return lookupDefaultLocationId(DEFAULT_LOCATION_CODE);
+               }
+               return completedFuture(locationId);
+            })
+        .exceptionally(t -> {
+          logger.error("Exception looking up location id", t);
+          return null;
+        });
+  }
+
+  public CompletableFuture<String> lookupDefaultLocationId(String defaultLocation) {
+    logger.info("No location received, using the default location");
     //Always getting the first location until GOBI responds with how to handle locations for various orders
-      String query = HelperUtils.encodeValue(String.format(CQL_CODE_STRING_FMT, "*"), logger);
+      String query = HelperUtils.encodeValue(String.format(CQL_CODE_STRING_FMT, defaultLocation), logger);
       String endpoint = String.format(LOCATIONS_ENDPOINT+QUERY, query);
       return handleGetRequest(endpoint)
         .thenApply(HelperUtils::extractLocationId)
@@ -178,6 +198,7 @@ public class PostGobiOrdersHelper {
         });
 
   }
+
   public CompletableFuture<List<String>> lookupMaterialTypeId(String materialType) {
       String query = HelperUtils.encodeValue(String.format("name==%s", materialType), logger);
       String endpoint = String.format(MATERIAL_TYPES_ENDPOINT+QUERY, query);

--- a/src/main/resources/ListedElectronicMonograph.json
+++ b/src/main/resources/ListedElectronicMonograph.json
@@ -278,6 +278,12 @@
           "dataSource": {
             "default": "Supplier's unique order line reference number"
           }
+        },
+        {
+          "field": "WORKFLOW_STATUS",
+          "dataSource": {
+            "default": "Open"
+          }
         }
       ]
     }

--- a/src/main/resources/ListedElectronicSerial.json
+++ b/src/main/resources/ListedElectronicSerial.json
@@ -117,6 +117,14 @@
           }
         },
         {
+          "field": "LOCATION",
+          "dataSource": {
+            "default" : "*",
+            "translation": "lookupDefaultLocationId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "MANUAL_PO",
           "dataSource": {
             "default": "false",

--- a/src/main/resources/ListedPrintSerial.json
+++ b/src/main/resources/ListedPrintSerial.json
@@ -78,6 +78,14 @@
           }
         },
         {
+          "field": "LOCATION",
+          "dataSource": {
+            "default" : "*",
+            "translation": "lookupDefaultLocationId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "MANUAL_PO",
           "dataSource": {
             "default": "false",

--- a/src/main/resources/UnlistedPrintSerial.json
+++ b/src/main/resources/UnlistedPrintSerial.json
@@ -70,6 +70,14 @@
           }
         },
         {
+          "field": "LOCATION",
+          "dataSource": {
+            "default" : "*",
+            "translation": "lookupDefaultLocationId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "MANUAL_PO",
           "dataSource": {
             "default": "false",

--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -112,6 +112,7 @@
             "toInteger",
             "lookupMaterialTypeId",
             "lookupLocationId",
+            "lookupDefaultLocationId",
             "lookupVendorId",
             "getPurchaseOptionCode",
             "toDate",


### PR DESCRIPTION
https://issues.folio.org/browse/MODGOBI-52
https://issues.folio.org/browse/MODGOBI-54

## Purpose
Default Location must be fetched only if it not provided. Also the workflow status of an order must be OPEN irrespective of the order type.

## Approach
1) Created a new method to handle pulling the first location from the locations endpoint and also added this as a fall back method if the look up for the provided location fails
2) To prevent sending a null entry for product t id, adding a new product id entry in the list if the product id and type both are present. 

#### TODOS and Open Questions
The API tests will still fail after this change as the material type is a required field for interaction with inventory. This will be fixed as part of another story 
https://issues.folio.org/browse/MODGOBI-57

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
