### PR TITLE
MODGOBI-52, MODGOBI-54: Use default location only if not specified 

### DIFF
--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -75,7 +75,6 @@ public class Mapper {
 
             setObjectIfPresent(adjustment, o -> compPO.setAdjustment((Adjustment) o));
             setObjectIfPresent(detail, o -> pol.setDetails((Details) o));
-            setObjectIfPresent(detail, o -> pol.setDetails((Details) o));
             setObjectIfPresent(cost, o -> pol.setCost((Cost) o));
             setObjectIfPresent(eresource, o -> pol.setEresource((Eresource) o));
             setObjectIfPresent(vendorDetail, o -> pol.setVendorDetail((VendorDetail) o));

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -70,48 +70,48 @@ public class Mapper {
       mapVendorDependentFields(futures, eresource, physical, compPO, claim, doc);
 
       CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[futures.size()]))
-          .thenAccept(v -> {
-            compPO.setTotalItems(location.getQuantity());
+        .thenAccept(v -> {
+          compPO.setTotalItems(location.getQuantity());
 
-            setObjectIfPresent(adjustment, o -> compPO.setAdjustment((Adjustment) o));
-            setObjectIfPresent(detail, o -> pol.setDetails((Details) o));
-            setObjectIfPresent(cost, o -> pol.setCost((Cost) o));
-            setObjectIfPresent(eresource, o -> pol.setEresource((Eresource) o));
-            setObjectIfPresent(vendorDetail, o -> pol.setVendorDetail((VendorDetail) o));
-            setObjectIfPresent(renewal, o -> compPO.setRenewal((Renewal) o));
-            setObjectIfPresent(physical, o -> pol.setPhysical((Physical) o));
-            setObjectIfPresent(source, o -> pol.setSource((Source) o));
+          setObjectIfPresent(adjustment, o -> compPO.setAdjustment((Adjustment) o));
+          setObjectIfPresent(detail, o -> pol.setDetails((Details) o));
+          setObjectIfPresent(cost, o -> pol.setCost((Cost) o));
+          setObjectIfPresent(eresource, o -> pol.setEresource((Eresource) o));
+          setObjectIfPresent(vendorDetail, o -> pol.setVendorDetail((VendorDetail) o));
+          setObjectIfPresent(renewal, o -> compPO.setRenewal((Renewal) o));
+          setObjectIfPresent(physical, o -> pol.setPhysical((Physical) o));
+          setObjectIfPresent(source, o -> pol.setSource((Source) o));
 
-            setObjectIfPresent(location, o -> {
-              List<Location> locations = new ArrayList<>();
-              locations.add(location);
-              pol.setLocations(locations);
-            });
-            setObjectIfPresent(contributor, o -> {
-              List<Contributor> contributors = new ArrayList<>();
-              contributors.add(contributor);
-              pol.setContributors(contributors);
-            });
-            setObjectIfPresent(reportingCode, o -> {
-              List<ReportingCode> reportingCodes = new ArrayList<>();
-              reportingCodes.add(reportingCode);
-              pol.setReportingCodes(reportingCodes);
-            });
-            setObjectIfPresent(claim, o -> {
-              List<Claim> claims = new ArrayList<>();
-              claims.add(claim);
-              pol.setClaims(claims);
-            });
-            setObjectIfPresent(fundDistribution, o -> {
-              List<FundDistribution> fundDistributions = new ArrayList<>();
-              fundDistributions.add(fundDistribution);
-              pol.setFundDistribution(fundDistributions);
-            });
-            poLines.add(pol);
-
-            compPO.setCompositePoLines(poLines);
-            future.complete(compPO);
+          setObjectIfPresent(location, o -> {
+            List<Location> locations = new ArrayList<>();
+            locations.add(location);
+            pol.setLocations(locations);
           });
+          setObjectIfPresent(contributor, o -> {
+            List<Contributor> contributors = new ArrayList<>();
+            contributors.add(contributor);
+            pol.setContributors(contributors);
+          });
+          setObjectIfPresent(reportingCode, o -> {
+            List<ReportingCode> reportingCodes = new ArrayList<>();
+            reportingCodes.add(reportingCode);
+            pol.setReportingCodes(reportingCodes);
+          });
+          setObjectIfPresent(claim, o -> {
+            List<Claim> claims = new ArrayList<>();
+            claims.add(claim);
+            pol.setClaims(claims);
+          });
+          setObjectIfPresent(fundDistribution, o -> {
+            List<FundDistribution> fundDistributions = new ArrayList<>();
+            fundDistributions.add(fundDistribution);
+            pol.setFundDistribution(fundDistributions);
+          });
+          poLines.add(pol);
+
+          compPO.setCompositePoLines(poLines);
+          future.complete(compPO);
+        });
     } catch (Exception e) {
       throw new CompletionException(e);
     }
@@ -131,42 +131,42 @@ public class Mapper {
   private void mapVendorDependentFields(List<CompletableFuture<?>> futures, Eresource eresource, Physical physical,
       CompositePurchaseOrder compPo, Claim claim, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.VENDOR))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              if (null != o) {
-                Vendor vendor = (Vendor) o;
-                compPo.setVendor(vendor.getId());
-                // Map Receipt dates based on the order format type
-                LocalDateTime dt = LocalDateTime.from(new Date().toInstant()
-                    .atOffset(ZoneOffset.UTC));
-                Optional.ofNullable(mappings.get(Mapping.Field.PO_LINE_ORDER_FORMAT))
-                    .ifPresent(orderformat -> orderformat.resolve(doc)
-                        .thenAccept(format -> {
-                          if ((format.toString())
-                              .equalsIgnoreCase(CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE.toString())) {
-                            Optional.ofNullable(vendor.getExpectedActivationInterval())
-                                .ifPresent(activationDue -> {
-                                  eresource.setActivationDue(activationDue);
-                                  eresource.setExpectedActivation(Date.from(dt.plusDays(activationDue)
-                                      .toInstant(ZoneOffset.UTC)));
-                                });
-                          } else {
-                            Optional.ofNullable(vendor.getExpectedReceiptInterval())
-                                .ifPresent(expectedReceiptInterval -> physical
-                                    .setExpectedReceiptDate(Date.from(dt.plusDays(expectedReceiptInterval)
-                                        .toInstant(ZoneOffset.UTC))));
-                          }
-                        })
-                        .exceptionally(Mapper::logException));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          if (null != o) {
+            Vendor vendor = (Vendor) o;
+            compPo.setVendor(vendor.getId());
+            // Map Receipt dates based on the order format type
+            LocalDateTime dt = LocalDateTime.from(new Date().toInstant()
+              .atOffset(ZoneOffset.UTC));
+            Optional.ofNullable(mappings.get(Mapping.Field.PO_LINE_ORDER_FORMAT))
+              .ifPresent(orderformat -> orderformat.resolve(doc)
+                .thenAccept(format -> {
+                  if ((format.toString())
+                    .equalsIgnoreCase(CompositePoLine.OrderFormat.ELECTRONIC_RESOURCE.toString())) {
+                    Optional.ofNullable(vendor.getExpectedActivationInterval())
+                      .ifPresent(activationDue -> {
+                        eresource.setActivationDue(activationDue);
+                        eresource.setExpectedActivation(Date.from(dt.plusDays(activationDue)
+                          .toInstant(ZoneOffset.UTC)));
+                      });
+                  } else {
+                    Optional.ofNullable(vendor.getExpectedReceiptInterval())
+                      .ifPresent(expectedReceiptInterval -> physical
+                        .setExpectedReceiptDate(Date.from(dt.plusDays(expectedReceiptInterval)
+                          .toInstant(ZoneOffset.UTC))));
+                  }
+                })
+                .exceptionally(Mapper::logException));
 
-                claim.setGrace(vendor.getClaimingInterval());
-                Optional.ofNullable(mappings.get(Mapping.Field.CLAIM_GRACE))
-                    .ifPresent(grace -> futures.add(grace.resolve(doc)
-                        .thenAccept(claimgrace -> claim.setGrace((Integer) claimgrace))
-                        .exceptionally(Mapper::logException)));
-              }
-            })
-            .exceptionally(Mapper::logException)));
+            claim.setGrace(vendor.getClaimingInterval());
+            Optional.ofNullable(mappings.get(Mapping.Field.CLAIM_GRACE))
+              .ifPresent(grace -> futures.add(grace.resolve(doc)
+                .thenAccept(claimgrace -> claim.setGrace((Integer) claimgrace))
+                .exceptionally(Mapper::logException)));
+          }
+        })
+        .exceptionally(Mapper::logException)));
 
   }
 
@@ -178,485 +178,487 @@ public class Mapper {
 
   private void mapReportingCodes(List<CompletableFuture<?>> futures, ReportingCode reportingCode, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.REPORTING_DESCRIPTION))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> reportingCode.setDescription((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> reportingCode.setDescription((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.REPORTING_CODE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> reportingCode.setCode((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> reportingCode.setCode((String) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapContributor(List<CompletableFuture<?>> futures, Contributor contributor, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.CONTRIBUTOR))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> contributor.setContributor((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> contributor.setContributor((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.CONTRIBUTOR_TYPE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> contributor.setContributorType((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> contributor.setContributorType((String) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapSource(List<CompletableFuture<?>> futures, Source source, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.SOURCE_CODE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> source.setCode((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> source.setCode((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.SOURCE_DESCRIPTION))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> source.setDescription((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> source.setDescription((String) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapAdjustment(List<CompletableFuture<?>> futures, Adjustment adjustment, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.CREDIT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setCredit((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setCredit((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.DISCOUNT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setDiscount((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setDiscount((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.INSURANCE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setInsurance((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setInsurance((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.OVERHEAD))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setOverhead((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setOverhead((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.SHIPMENT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setShipment((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setShipment((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.TAX_1))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setTax1((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setTax1((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.TAX_2))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setTax2((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setTax2((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.USE_PRORATE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> adjustment.setUseProRate((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> adjustment.setUseProRate((Boolean) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapPhysical(List<CompletableFuture<?>> futures, Physical physical, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.MATERIAL_SUPPLIER))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> physical.setMaterialSupplier((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> physical.setMaterialSupplier((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RECEIPT_DUE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> physical.setReceiptDue((Date) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> physical.setReceiptDue((Date) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.VOLUMES))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              List<String> volumes = new ArrayList<>();
-              volumes.add((String) o);
-              physical.setVolumes(volumes);
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          List<String> volumes = new ArrayList<>();
+          volumes.add((String) o);
+          physical.setVolumes(volumes);
+        })
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapRenewal(List<CompletableFuture<?>> futures, Renewal renewal, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.RENEWAL_CYCLE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> renewal.setCycle(Renewal.Cycle.fromValue((String) o)))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> renewal.setCycle(Renewal.Cycle.fromValue((String) o)))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RENEWAL_INTERVAL))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> renewal.setInterval((Integer) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> renewal.setInterval((Integer) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RENEWAL_MANUAL))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> renewal.setManualRenewal((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> renewal.setManualRenewal((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RENEWAL_DATE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> renewal.setRenewalDate((Date) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> renewal.setRenewalDate((Date) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RENEWAL_REVIEW_PERIOD))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> renewal.setReviewPeriod((Integer) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> renewal.setReviewPeriod((Integer) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapClaims(List<CompletableFuture<?>> futures, Claim claim, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.CLAIMED))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> claim.setClaimed((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> claim.setClaimed((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.CLAIM_SENT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> claim.setSent((Date) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> claim.setSent((Date) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapPurchaseOrder(List<CompletableFuture<?>> futures, CompositePurchaseOrder compPo, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.ORDER_TYPE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> compPo.setOrderType(CompositePurchaseOrder.OrderType.fromValue((String) o)))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> compPo.setOrderType(CompositePurchaseOrder.OrderType.fromValue((String) o)))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.APPROVED))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> compPo.setApproved((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> compPo.setApproved((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.ASSIGNED_TO))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> compPo.setAssignedTo((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> compPo.setAssignedTo((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.MANUAL_PO))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> compPo.setManualPo((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> compPo.setManualPo((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.NOTES))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              List<String> notes = new ArrayList<>();
-              notes.add((String) o);
-              compPo.setNotes(notes);
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          List<String> notes = new ArrayList<>();
+          notes.add((String) o);
+          compPo.setNotes(notes);
+        })
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RE_ENCUMBER))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> compPo.setReEncumber((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> compPo.setReEncumber((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.TOTAL_ESTIMATED_PRICE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> compPo.setTotalEstimatedPrice((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> compPo.setTotalEstimatedPrice((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.WORKFLOW_STATUS))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> compPo.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.fromValue((String) o)))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> compPo.setWorkflowStatus(CompositePurchaseOrder.WorkflowStatus.fromValue((String) o)))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapPurchaseOrderLineStrings(List<CompletableFuture<?>> futures, CompositePoLine pol, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.REQUESTER))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setRequester((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setRequester((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.TITLE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setTitle((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setTitle((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.CANCELLATION_RESTRICTION_NOTE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setCancellationRestrictionNote((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setCancellationRestrictionNote((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.DESCRIPTION))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setDescription((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setDescription((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.DONOR))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setDonor((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setDonor((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.OWNER))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setOwner((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setOwner((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.SELECTOR))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setSelector((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setSelector((String) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapPurchaseOrderLine(List<CompletableFuture<?>> futures, CompositePoLine pol, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.ACQUISITION_METHOD))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setAcquisitionMethod(CompositePoLine.AcquisitionMethod.fromValue(o.toString())))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setAcquisitionMethod(CompositePoLine.AcquisitionMethod.fromValue(o.toString())))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.ALERT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              Alert alert = new Alert();
-              alert.setAlert((String) o);
-              List<Alert> alerts = new ArrayList<>();
-              alerts.add(alert);
-              pol.setAlerts(alerts);
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          Alert alert = new Alert();
+          alert.setAlert((String) o);
+          List<Alert> alerts = new ArrayList<>();
+          alerts.add(alert);
+          pol.setAlerts(alerts);
+        })
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.CANCELLATION_RESTRICTION))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setCancellationRestriction((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setCancellationRestriction((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PO_LINE_ORDER_FORMAT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setOrderFormat(CompositePoLine.OrderFormat.fromValue((String) o)))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setOrderFormat(CompositePoLine.OrderFormat.fromValue((String) o)))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.COLLECTION))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setCollection((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setCollection((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PO_LINE_DESCRIPTION))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setPoLineDescription((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setPoLineDescription((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PO_LINE_PAYMENT_STATUS))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setPaymentStatus(CompositePoLine.PaymentStatus.fromValue((String) o)))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setPaymentStatus(CompositePoLine.PaymentStatus.fromValue((String) o)))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PUBLICATION_DATE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setPublicationDate((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setPublicationDate((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PUBLISHER))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setPublisher((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setPublisher((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PURCHASE_ORDER_ID))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setPurchaseOrderId((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setPurchaseOrderId((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RECEIPT_DATE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setReceiptDate((Date) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setReceiptDate((Date) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RUSH))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setRush((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setRush((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.TAGS))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              List<String> tags = new ArrayList<>();
-              tags.add((String) o);
-              pol.setTags(tags);
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          List<String> tags = new ArrayList<>();
+          tags.add((String) o);
+          pol.setTags(tags);
+        })
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PO_LINE_RECEIPT_STATUS))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> pol.setReceiptStatus(CompositePoLine.ReceiptStatus.fromValue((String) o)))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> pol.setReceiptStatus(CompositePoLine.ReceiptStatus.fromValue((String) o)))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapCost(List<CompletableFuture<?>> futures, Cost cost, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.CURRENCY))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> cost.setCurrency((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> cost.setCurrency((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.LIST_PRICE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> cost.setListPrice((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> cost.setListPrice((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.PO_LINE_ESTIMATED_PRICE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> cost.setPoLineEstimatedPrice((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> cost.setPoLineEstimatedPrice((Double) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.QUANTITY_ORDERED_ELECTRONIC))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> cost.setQuantityElectronic((Integer) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> cost.setQuantityElectronic((Integer) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.QUANTITY_ORDERED_PHYSICAL))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> cost.setQuantityPhysical((Integer) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> cost.setQuantityPhysical((Integer) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapDetail(List<CompletableFuture<?>> futures, Details detail, ProductId productId, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.MATERIAL_TYPE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> detail.setMaterialTypes((List<String>) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> detail.setMaterialTypes((List<String>) o))
+        .exceptionally(Mapper::logException)));
 
-    //Adding a new entry to product id only if the product ID and product id type are present
-    // as both of them are together are mandatory to create an inventory instance
+    // Adding a new entry to product id only if the product ID and product id
+    // type are present
+    // as both of them are together are mandatory to create an inventory
+    // instance
     Optional.ofNullable(mappings.get(Mapping.Field.PRODUCT_ID))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              productId.setProductId(o.toString());
-              Optional.ofNullable(mappings.get(Mapping.Field.PRODUCT_ID_TYPE))
-                  .ifPresent(prodidtype -> prodidtype.resolve(doc)
-                      .thenAccept(
-                          idType -> {
-                              productId.setProductIdType(ProductId.ProductIdType.fromValue((String) idType));
-                              List<ProductId> ids = new ArrayList<>();
-                              ids.add(productId);
-                              detail.setProductIds(ids);
-                          }));
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          productId.setProductId(o.toString());
+          Optional.ofNullable(mappings.get(Mapping.Field.PRODUCT_ID_TYPE))
+            .ifPresent(prodidtype -> prodidtype.resolve(doc)
+              .thenAccept(
+                  idType -> {
+                    productId.setProductIdType(ProductId.ProductIdType.fromValue((String) idType));
+                    List<ProductId> ids = new ArrayList<>();
+                    ids.add(productId);
+                    detail.setProductIds(ids);
+                  }));
+        })
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.RECEIVING_NOTE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> detail.setReceivingNote((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> detail.setReceivingNote((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.SUBSCRIPTION_FROM))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> detail.setSubscriptionFrom((Date) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> detail.setSubscriptionFrom((Date) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.SUBSCRIPTION_INTERVAL))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> detail.setSubscriptionInterval((Integer) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> detail.setSubscriptionInterval((Integer) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.SUBSCRIPTION_TO))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> detail.setSubscriptionTo((Date) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> detail.setSubscriptionTo((Date) o))
+        .exceptionally(Mapper::logException)));
 
   }
 
   private void mapEresource(List<CompletableFuture<?>> futures, Eresource eresource, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.ACCESS_PROVIDER))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> Optional.ofNullable(o)
-                .ifPresent(vendor -> eresource.setAccessProvider(((Vendor) o).getId())))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> Optional.ofNullable(o)
+          .ifPresent(vendor -> eresource.setAccessProvider(((Vendor) o).getId())))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.USER_LIMIT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> eresource.setUserLimit((Integer) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> eresource.setUserLimit((Integer) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.ACTIVATED))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> eresource.setActivated((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> eresource.setActivated((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.CREATE_INVENTORY))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> eresource.setCreateInventory((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> eresource.setCreateInventory((Boolean) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.LICENSE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> eresource.setLicense((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> eresource.setLicense((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.TRIAL))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> eresource.setTrial((Boolean) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> eresource.setTrial((Boolean) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapFundDistibution(List<CompletableFuture<?>> futures, FundDistribution fundDistribution, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.FUND_CODE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> fundDistribution.setCode((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> fundDistribution.setCode((String) o))
+        .exceptionally(Mapper::logException)));
     Optional.ofNullable(mappings.get(Mapping.Field.FUND_PERCENTAGE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> fundDistribution.setPercentage((Double) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> fundDistribution.setPercentage((Double) o))
+        .exceptionally(Mapper::logException)));
     Optional.ofNullable(mappings.get(Mapping.Field.ENCUMBERANCE))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> fundDistribution.setEncumbrance((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> fundDistribution.setEncumbrance((String) o))
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapLocation(List<CompletableFuture<?>> futures, Location location, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.LOCATION))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> location.setLocationId((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> location.setLocationId((String) o))
+        .exceptionally(Mapper::logException)));
 
     // A GOBI order can only be one of the below type per order, hence the total
     // quantity will be the same
     Optional.ofNullable(mappings.get(Mapping.Field.QUANTITY_ORDERED_ELECTRONIC))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              location.setQuantityElectronic((Integer) o);
-              location.setQuantity((Integer) o);
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          location.setQuantityElectronic((Integer) o);
+          location.setQuantity((Integer) o);
+        })
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.QUANTITY_ORDERED_PHYSICAL))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              location.setQuantityPhysical((Integer) o);
-              location.setQuantity((Integer) o);
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          location.setQuantityPhysical((Integer) o);
+          location.setQuantity((Integer) o);
+        })
+        .exceptionally(Mapper::logException)));
   }
 
   private void mapVendorDetail(List<CompletableFuture<?>> futures, VendorDetail vendorDetail, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.INSTRUCTIONS))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> vendorDetail.setInstructions((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> vendorDetail.setInstructions((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.NOTE_FROM_VENDOR))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> vendorDetail.setNoteFromVendor((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> vendorDetail.setNoteFromVendor((String) o))
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.VENDOR_REF_NO))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> {
-              vendorDetail.setRefNumber((String) o);
-              Optional.ofNullable(mappings.get(Mapping.Field.VENDOR_REF_NO_TYPE))
-                  .ifPresent(refType -> futures.add(refType.resolve(doc)
-                      .thenAccept(numberType -> vendorDetail
-                          .setRefNumberType(VendorDetail.RefNumberType.fromValue((String) numberType)))
-                      .exceptionally(Mapper::logException)));
-            })
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> {
+          vendorDetail.setRefNumber((String) o);
+          Optional.ofNullable(mappings.get(Mapping.Field.VENDOR_REF_NO_TYPE))
+            .ifPresent(refType -> futures.add(refType.resolve(doc)
+              .thenAccept(numberType -> vendorDetail
+                .setRefNumberType(VendorDetail.RefNumberType.fromValue((String) numberType)))
+              .exceptionally(Mapper::logException)));
+        })
+        .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.VENDOR_ACCOUNT))
-        .ifPresent(field -> futures.add(field.resolve(doc)
-            .thenAccept(o -> vendorDetail.setVendorAccount((String) o))
-            .exceptionally(Mapper::logException)));
+      .ifPresent(field -> futures.add(field.resolve(doc)
+        .thenAccept(o -> vendorDetail.setVendorAccount((String) o))
+        .exceptionally(Mapper::logException)));
   }
 
   public boolean isObjectEmpty(Object instance) {
     for (Field f : instance.getClass()
-        .getDeclaredFields()) {
+      .getDeclaredFields()) {
       f.setAccessible(true);
       try {
         if (f.get(instance) != null)
@@ -700,7 +702,7 @@ public class Mapper {
       StringBuilder sb = new StringBuilder();
       for (int i = 0; i < nodes.getLength(); i++) {
         sb.append(nodes.item(i)
-            .getTextContent());
+          .getTextContent());
       }
       return sb.length() > 0 ? sb.toString() : null;
     }
@@ -713,10 +715,10 @@ public class Mapper {
       for (int i = 0; i < nodes.getLength(); i++) {
         if (product == null) {
           product = BigDecimal.exact(nodes.item(i)
-              .getTextContent());
+            .getTextContent());
         } else {
           product = product.$times(BigDecimal.exact(nodes.item(i)
-              .getTextContent()));
+            .getTextContent()));
         }
       }
       return String.valueOf(product);

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -71,9 +71,6 @@ public class Mapper {
 
       CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[futures.size()]))
           .thenAccept(v -> {
-            List<ProductId> ids = new ArrayList<>();
-            ids.add(productId);
-            detail.setProductIds(ids);
             compPO.setTotalItems(location.getQuantity());
 
             setObjectIfPresent(adjustment, o -> compPO.setAdjustment((Adjustment) o));
@@ -523,7 +520,12 @@ public class Mapper {
               Optional.ofNullable(mappings.get(Mapping.Field.PRODUCT_ID_TYPE))
                   .ifPresent(prodidtype -> prodidtype.resolve(doc)
                       .thenAccept(
-                          idType -> productId.setProductIdType(ProductId.ProductIdType.fromValue((String) idType))));
+                          idType -> {
+                              productId.setProductIdType(ProductId.ProductIdType.fromValue((String) idType));
+                              List<ProductId> ids = new ArrayList<>();
+                              ids.add(productId);
+                              detail.setProductIds(ids);
+                          }));
             })
             .exceptionally(Mapper::logException)));
 

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -512,6 +512,8 @@ public class Mapper {
             .thenAccept(o -> detail.setMaterialTypes((List<String>) o))
             .exceptionally(Mapper::logException)));
 
+    //Adding a new entry to product id only if the product ID and product id type are present
+    // as both of them are together are mandatory to create an inventory instance
     Optional.ofNullable(mappings.get(Mapping.Field.PRODUCT_ID))
         .ifPresent(field -> futures.add(field.resolve(doc)
             .thenAccept(o -> {

--- a/src/main/java/org/folio/gobi/MappingHelper.java
+++ b/src/main/java/org/folio/gobi/MappingHelper.java
@@ -121,8 +121,8 @@ public class MappingHelper {
             translatedValue = postGobiOrdersHelper.lookupLocationId(data);
             break;
           case LOOKUP_DEFAULT_LOCATION_ID:
-              translatedValue = postGobiOrdersHelper.lookupDefaultLocationId(data);
-              break;
+            translatedValue = postGobiOrdersHelper.lookupDefaultLocationId(data);
+            break;
           case LOOKUP_MATERIAL_TYPE_ID:
             translatedValue = postGobiOrdersHelper.lookupMaterialTypeId(data);
             break;

--- a/src/main/java/org/folio/gobi/MappingHelper.java
+++ b/src/main/java/org/folio/gobi/MappingHelper.java
@@ -120,6 +120,9 @@ public class MappingHelper {
           case LOOKUP_LOCATION_ID:
             translatedValue = postGobiOrdersHelper.lookupLocationId(data);
             break;
+          case LOOKUP_DEFAULT_LOCATION_ID:
+              translatedValue = postGobiOrdersHelper.lookupDefaultLocationId(data);
+              break;
           case LOOKUP_MATERIAL_TYPE_ID:
             translatedValue = postGobiOrdersHelper.lookupMaterialTypeId(data);
             break;

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -172,17 +172,17 @@ public class PostGobiOrdersHelper {
     String query = HelperUtils.encodeValue(String.format(CQL_CODE_STRING_FMT, location), logger);
     String endpoint = String.format(LOCATIONS_ENDPOINT + QUERY, query);
     return handleGetRequest(endpoint)
-        .thenCompose(locations -> {
-              String locationId = HelperUtils.extractLocationId(locations);
-               if (StringUtils.isEmpty(locationId)) {
-        	   return lookupDefaultLocationId(DEFAULT_LOCATION_CODE);
-               }
-               return completedFuture(locationId);
-            })
-        .exceptionally(t -> {
-          logger.error("Exception looking up location id", t);
-          return null;
-        });
+      .thenCompose(locations -> {
+        String locationId = HelperUtils.extractLocationId(locations);
+        if (StringUtils.isEmpty(locationId)) {
+          return lookupDefaultLocationId(DEFAULT_LOCATION_CODE);
+        }
+        return completedFuture(locationId);
+      })
+      .exceptionally(t -> {
+        logger.error("Exception looking up location id", t);
+        return null;
+      });
   }
 
   public CompletableFuture<String> lookupDefaultLocationId(String defaultLocation) {

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -7,7 +7,8 @@ import static org.folio.rest.jaxrs.resource.Gobi.PostGobiOrdersResponse.respond4
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import org.apache.commons.lang.StringUtils;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
@@ -61,6 +62,7 @@ public class PostGobiOrdersHelper {
   public static final String CQL_CODE_STRING_FMT = "code==\"%s\"";
   public static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String EXCEPTION_CALLING_ENDPOINT_MSG = "Exception calling {} {}";
+  private static final String DEFAULT_LOCATION_CODE = "*";
 
   private final HttpClientInterface httpClient;
   private final Context ctx;
@@ -167,8 +169,26 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> lookupLocationId(String location) {
     logger.info("Received location is {}", location);
+    String query = HelperUtils.encodeValue(String.format(CQL_CODE_STRING_FMT, location), logger);
+    String endpoint = String.format(LOCATIONS_ENDPOINT + QUERY, query);
+    return handleGetRequest(endpoint)
+        .thenCompose(locations -> {
+              String locationId = HelperUtils.extractLocationId(locations);
+               if (StringUtils.isEmpty(locationId)) {
+        	   return lookupDefaultLocationId(DEFAULT_LOCATION_CODE);
+               }
+               return completedFuture(locationId);
+            })
+        .exceptionally(t -> {
+          logger.error("Exception looking up location id", t);
+          return null;
+        });
+  }
+
+  public CompletableFuture<String> lookupDefaultLocationId(String defaultLocation) {
+    logger.info("No location received, using the default location");
     //Always getting the first location until GOBI responds with how to handle locations for various orders
-      String query = HelperUtils.encodeValue(String.format(CQL_CODE_STRING_FMT, "*"), logger);
+      String query = HelperUtils.encodeValue(String.format(CQL_CODE_STRING_FMT, defaultLocation), logger);
       String endpoint = String.format(LOCATIONS_ENDPOINT+QUERY, query);
       return handleGetRequest(endpoint)
         .thenApply(HelperUtils::extractLocationId)
@@ -178,6 +198,7 @@ public class PostGobiOrdersHelper {
         });
 
   }
+
   public CompletableFuture<List<String>> lookupMaterialTypeId(String materialType) {
       String query = HelperUtils.encodeValue(String.format("name==%s", materialType), logger);
       String endpoint = String.format(MATERIAL_TYPES_ENDPOINT+QUERY, query);

--- a/src/main/resources/ListedElectronicMonograph.json
+++ b/src/main/resources/ListedElectronicMonograph.json
@@ -278,6 +278,12 @@
           "dataSource": {
             "default": "Supplier's unique order line reference number"
           }
+        },
+        {
+          "field": "WORKFLOW_STATUS",
+          "dataSource": {
+            "default": "Open"
+          }
         }
       ]
     }

--- a/src/main/resources/ListedElectronicSerial.json
+++ b/src/main/resources/ListedElectronicSerial.json
@@ -117,6 +117,14 @@
           }
         },
         {
+          "field": "LOCATION",
+          "dataSource": {
+            "default" : "*",
+            "translation": "lookupDefaultLocationId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "MANUAL_PO",
           "dataSource": {
             "default": "false",

--- a/src/main/resources/ListedPrintSerial.json
+++ b/src/main/resources/ListedPrintSerial.json
@@ -78,6 +78,14 @@
           }
         },
         {
+          "field": "LOCATION",
+          "dataSource": {
+            "default" : "*",
+            "translation": "lookupDefaultLocationId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "MANUAL_PO",
           "dataSource": {
             "default": "false",

--- a/src/main/resources/UnlistedPrintSerial.json
+++ b/src/main/resources/UnlistedPrintSerial.json
@@ -70,6 +70,14 @@
           }
         },
         {
+          "field": "LOCATION",
+          "dataSource": {
+            "default" : "*",
+            "translation": "lookupDefaultLocationId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "MANUAL_PO",
           "dataSource": {
             "default": "false",

--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -112,6 +112,7 @@
             "toInteger",
             "lookupMaterialTypeId",
             "lookupLocationId",
+            "lookupDefaultLocationId",
             "lookupVendorId",
             "getPurchaseOptionCode",
             "toDate",


### PR DESCRIPTION
https://issues.folio.org/browse/MODGOBI-52
https://issues.folio.org/browse/MODGOBI-54

## Purpose
Default Location must be fetched only if it not provided. Also the workflow status of an order must be OPEN irrespective of the order type.

## Approach
1. Created a new method to handle pulling the first location from the locations endpoint and also added this as a fall back method if the look up for the provided location fails
2. To prevent sending a null entry for product t id, adding a new product id entry in the list if the product id and type both are present.

#### TODOS and Open Questions
The API tests will still fail after this change as the material type is a required field for interaction with inventory. This will be fixed as part of another story
https://issues.folio.org/browse/MODGOBI-57

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
