### PR TITLE
MODGOBI-77 Contributor-name-type is required for contributor added to POL

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -25,6 +25,7 @@
             "orders.collection.get",
             "orders.item.get",
             "orders.item.put",
+            "inventory-storage.contributor-name-types.collection.get",
             "inventory-storage.material-types.collection.get",
             "inventory-storage.locations.collection.get",
             "inventory-storage.identifier-types.collection.get",
@@ -44,6 +45,10 @@
     {
       "id": "configuration",
       "version": "2.0"
+    },
+    {
+      "id": "contributor-name-types",
+      "version": "1.2"
     },
     {
       "id": "material-types",

--- a/src/main/java/org/folio/gobi/HelperUtils.java
+++ b/src/main/java/org/folio/gobi/HelperUtils.java
@@ -11,6 +11,8 @@ import io.vertx.core.logging.Logger;
 
 public class HelperUtils {
 
+  public static final String CONTRIBUTOR_NAME_TYPES = "contributorNameTypes";
+
   private HelperUtils() {
 
   }
@@ -46,6 +48,9 @@ public class HelperUtils {
 
   public static String extractProductTypeId(JsonObject obj) {
     return extractIdOfFirst(obj, "identifierTypes");
+  }
+  public static String extractContributorNameTypeId(JsonObject obj) {
+    return extractIdOfFirst(obj, CONTRIBUTOR_NAME_TYPES);
   }
 
   public static String extractIdOfFirst(JsonObject obj, String arrField) {

--- a/src/main/java/org/folio/gobi/MappingHelper.java
+++ b/src/main/java/org/folio/gobi/MappingHelper.java
@@ -114,6 +114,9 @@ public class MappingHelper {
           case LOOKUP_MOCK:
             translatedValue = postGobiOrdersHelper.lookupMock(data);
             break;
+          case LOOKUP_CONTRIBUTOR_NAME_TYPE_ID:
+            translatedValue = postGobiOrdersHelper.lookupContributorNameTypeId(data);
+            break;
           case LOOKUP_LOCATION_ID:
             translatedValue = postGobiOrdersHelper.lookupLocationId(data);
             break;

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -324,7 +324,7 @@ public class PostGobiOrdersHelper {
       .thenCompose(typeId -> {
         if (StringUtils.isEmpty(typeId)) {
           if (DEFAULT_LOOKUP_CODE.equals(name)) {
-            logger.error("No any contributorNameType available");
+            logger.error("No contributorNameTypes are available");
             return completedFuture(null);
           }
           // the type is already a default value in the mappings, so fallback to first one

--- a/src/main/resources/ListedElectronicMonograph.json
+++ b/src/main/resources/ListedElectronicMonograph.json
@@ -54,6 +54,14 @@
           }
         },
         {
+          "field": "CONTRIBUTOR_NAME_TYPE",
+          "dataSource": {
+            "default": "Personal name",
+            "translation": "lookupContributorNameTypeId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "CURRENCY",
           "dataSource": {
             "from": "//ListPrice/Currency",

--- a/src/main/resources/ListedPrintMonograph.json
+++ b/src/main/resources/ListedPrintMonograph.json
@@ -39,6 +39,14 @@
           }
         },
         {
+          "field": "CONTRIBUTOR_NAME_TYPE",
+          "dataSource": {
+            "default": "Personal name",
+            "translation": "lookupContributorNameTypeId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "CURRENCY",
           "dataSource": {
             "from": "//ListPrice/Currency",

--- a/src/main/resources/UnlistedPrintMonograph.json
+++ b/src/main/resources/UnlistedPrintMonograph.json
@@ -39,6 +39,14 @@
           }
         },
         {
+          "field": "CONTRIBUTOR_NAME_TYPE",
+          "dataSource": {
+            "default": "Personal name",
+            "translation": "lookupContributorNameTypeId",
+            "translateDefault": true
+          }
+        },
+        {
           "field": "CURRENCY",
           "dataSource": {
             "from": "//ListPrice/Currency",

--- a/src/main/resources/mapping.json
+++ b/src/main/resources/mapping.json
@@ -22,7 +22,7 @@
         "CLAIM_SENT",
         "COLLECTION",
         "CONTRIBUTOR",
-        "CONTRIBUTOR_TYPE",
+        "CONTRIBUTOR_NAME_TYPE",
         "CREATE_INVENTORY",
         "CURRENCY",
         "DATE_ORDERED",
@@ -105,6 +105,7 @@
         },
         "translation": {
           "enum": [
+            "lookupContributorNameTypeId",
             "lookupLocationId",
             "lookupMaterialTypeId",
             "lookupFundId",

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -1219,17 +1219,17 @@ public class GOBIIntegrationServiceResourceImplTest {
       logger.info("got contributorNameTypes request: {}", ctx.request().query());
       String instruction = ctx.request().getHeader(MOCK_OKAPI_GET_CONTRIBUTOR_NAME_HEADER);
 
-      JsonObject productTypes = new JsonObject();
-      addServerRqRsData(HttpMethod.GET, CONTRIBUTOR_NAME_TYPES, productTypes);
+      JsonObject types = new JsonObject();
+      addServerRqRsData(HttpMethod.GET, CONTRIBUTOR_NAME_TYPES, types);
 
       String name = ctx.queryParam("query").get(0).split("==")[1];
 
       if (MOCK_INSTRUCTION_NOT_EXIST.equals(instruction)
           || (MOCK_INSTRUCTION_USE_DEFAULT.equals(instruction) && !DEFAULT_LOOKUP_CODE.equals(name))) {
-        productTypes.put(CONTRIBUTOR_NAME_TYPES, new JsonArray())
+        types.put(CONTRIBUTOR_NAME_TYPES, new JsonArray())
           .put(TOTAL_RECORDS, 0);
       } else {
-        productTypes.put(CONTRIBUTOR_NAME_TYPES, new JsonArray().add(new JsonObject().put(ID, randomUUID().toString())
+        types.put(CONTRIBUTOR_NAME_TYPES, new JsonArray().add(new JsonObject().put(ID, randomUUID().toString())
           .put(NAME, name)))
           .put(TOTAL_RECORDS, 1);
       }
@@ -1237,7 +1237,7 @@ public class GOBIIntegrationServiceResourceImplTest {
       ctx.response()
         .setStatusCode(200)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .end(productTypes.encodePrettily());
+        .end(types.encodePrettily());
     }
 
     private String randomDigits(int len) {

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -870,6 +870,12 @@ public class GOBIIntegrationServiceResourceImplTest {
     assertNotNull(poLine.getOrderFormat());
     assertNotNull(poLine.getSource());
     assertNotNull(poLine.getTitle());
+    if (!poLine.getContributors().isEmpty()) {
+      poLine.getContributors().forEach(contributor -> {
+        assertNotNull(contributor.getContributor());
+        assertNotNull(contributor.getContributorNameTypeId());
+      });
+    }
   }
 
   public static class MockServer {

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -623,7 +623,10 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertTrue(compPO.getCompositePoLines().get(0).getContributors().isEmpty());
+    assertEquals(1, compPO.getCompositePoLines().get(0).getContributors().size());
+    // The contributor is mapped and the order is created even though there is no ContributorNameTypeId
+    assertNull(compPO.getCompositePoLines().get(0).getContributors().get(0).getContributorNameTypeId());
+    assertNotNull(compPO.getCompositePoLines().get(0).getContributors().get(0).getContributor());
 
     logger.info("End: Testing contributor is ignored if contributor name type cannot be resolved");
   }

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -623,10 +623,7 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertEquals(1, compPO.getCompositePoLines().get(0).getContributors().size());
-    // The contributor is mapped and the order is created even though there is no ContributorNameTypeId
-    assertNull(compPO.getCompositePoLines().get(0).getContributors().get(0).getContributorNameTypeId());
-    assertNotNull(compPO.getCompositePoLines().get(0).getContributors().get(0).getContributor());
+    assertTrue(compPO.getCompositePoLines().get(0).getContributors().isEmpty());
 
     logger.info("End: Testing contributor is ignored if contributor name type cannot be resolved");
   }

--- a/src/test/resources/MappingHelper/Custom_ListedElectronicSerial.json
+++ b/src/test/resources/MappingHelper/Custom_ListedElectronicSerial.json
@@ -322,9 +322,11 @@
           }
         },
         {
-          "field": "CONTRIBUTOR_TYPE",
+          "field": "CONTRIBUTOR_NAME_TYPE",
           "dataSource": {
-            "default": "3e12234b-26ad-4003-b1a4-2259f45f1afb"
+            "default": "Test Data",
+            "translation": "lookupContributorNameTypeId",
+            "translateDefault": true
           }
         },
         {

--- a/src/test/resources/MockData/compositePurchaseOrder.json
+++ b/src/test/resources/MockData/compositePurchaseOrder.json
@@ -26,7 +26,8 @@
     } ],
     "collection" : false,
     "contributors" : [ {
-      "contributorType" : "3e12234b-26ad-4003-b1a4-2259f45f1afb"
+      "contributor" : "Test",
+      "contributorNameTypeId" : "3e12234b-26ad-4003-b1a4-2259f45f1afb"
     } ],
     "cost" : {
       "listUnitPriceElectronic" : 0.0,
@@ -54,6 +55,7 @@
       "materialType" : "be44c321-ab73-43c4-a114-70f82fa13f17"
     },
     "fundDistribution" : [ {
+      "fundId" : "f5f1c495-7f7a-477a-b2e9-10eb043e37f4",
       "code" : "f5f1c495-7f7a-477a-b2e9-10eb043e37f4",
       "percentage" : 100.0
     } ],

--- a/src/test/resources/MockData/compositePurchaseOrder.json
+++ b/src/test/resources/MockData/compositePurchaseOrder.json
@@ -55,8 +55,8 @@
       "materialType" : "be44c321-ab73-43c4-a114-70f82fa13f17"
     },
     "fundDistribution" : [ {
-      "fundId" : "f5f1c495-7f7a-477a-b2e9-10eb043e37f4",
-      "code" : "f5f1c495-7f7a-477a-b2e9-10eb043e37f4",
+      "fundId" : "65032151-39a5-4cef-8810-5350eb316300",
+      "code" : "USHIST",
       "percentage" : 100.0
     } ],
     "locations" : [ {


### PR DESCRIPTION
## Purpose
[MODGOBI-77](https://issues.folio.org/browse/MODGOBI-77) Contributor-name-type is required for contributor added to POL
## Approach
In case the contributor is resolved, the logic searches for contributor name type id in the inventory by `Personal name` name or any if there is no such. If no any contributor name type found, the logic logs an error and ignores contributor (contributor name type is required field and without it validation will reject entire order)

#### TODOS and Open Questions
- [ ] Point to acq-models master commit once https://github.com/folio-org/acq-models/pull/145 is merged
- [ ] Merge together with changes for [MODORDERS-247](https://issues.folio.org/browse/MODORDERS-247): https://github.com/folio-org/mod-orders/pull/182

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
