### PR TITLE
exclude log properties from RMB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
               <properties>
                 <property>
                   <name>log4j.configuration</name>
-                  <value>${project.baseUri}src/main/resources/log4j.properties</value>
+                  <value>${project.baseUri}src/main/resources/log4j2.properties</value>
                 </property>
               </properties>
             </configuration>
@@ -428,6 +428,20 @@
                   </manifestEntries>
                 </transformer>
               </transformers>
+              <filters>
+                <filter>
+                  <artifact>org.folio:raml-module-builder</artifact>
+                  <excludes>
+                    <exclude>**/log4j2.properties</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>**/log4j.properties</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,15 @@
+status = info
+dest = err
+name = PropertiesConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ISO8601} %-5p [%-25t] %c{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.stdout.ref = STDOUT
+
+logger.netty.name = io.netty
+logger.netty.level = info
+logger.netty.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
## Purpose
While troubleshooting an unrelated issue it was discovered that the default log level is ERROR.  Upon investigation it appears this is due to multiple log configuration files being pulled into the fat jar.  In order to avoid this we should exclude log configuration files from RMB and use our own.

## Approach
* remove log4j.properties
* add a log4j2.properties (with level = info) in src/main/resources this will be pulled into the fat jar
* log4j2.properties (with level = debug) already lives in src/test/resources and is used during unit tests

Add exclude filters to the shade plugin:
* log4j2.properties from RMB
* log4j.properties from anywhere

Also, see https://issues.folio.org/browse/RMB-447

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
