### PR TITLE
MODORDERS-349 Make title schema changes to all APIs

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -41,7 +41,7 @@
   "requires": [
     {
       "id": "orders",
-      "version": "8.0"
+      "version": "9.0"
     },
     {
       "id": "configuration",

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -387,7 +387,7 @@ public class Mapper {
 
     Optional.ofNullable(mappings.get(Mapping.Field.TITLE))
       .ifPresent(field -> futures.add(field.resolve(doc)
-        .thenAccept(o -> pol.setTitle((String) o))
+        .thenAccept(o -> pol.setTitleOrPackage((String) o))
         .exceptionally(Mapper::logException)));
 
     Optional.ofNullable(mappings.get(Mapping.Field.CANCELLATION_RESTRICTION_NOTE))

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -1018,7 +1018,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     assertNotNull(poLine.getCost());
     assertNotNull(poLine.getOrderFormat());
     assertNotNull(poLine.getSource());
-    assertNotNull(poLine.getTitle());
+    assertNotNull(poLine.getTitleOrPackage());
     if (!poLine.getContributors().isEmpty()) {
       poLine.getContributors().forEach(contributor -> {
         assertNotNull(contributor.getContributor());

--- a/src/test/resources/MockData/compositePurchaseOrder.json
+++ b/src/test/resources/MockData/compositePurchaseOrder.json
@@ -81,7 +81,7 @@
         "Test Data"
       ]
     },
-    "title" : "BRANDS AND THEIR COMPANIES. (EBOOK VERSION)",
+    "titleOrPackage" : "BRANDS AND THEIR COMPANIES. (EBOOK VERSION)",
     "vendorDetail" : {
       "instructions" : "v.2 | Test Note to Ybp",
       "noteFromVendor" : "GALEA",


### PR DESCRIPTION
## Purpose
Handle breaking changes in [MODORDERS-349](https://issues.folio.org/browse/MODORDERS-349)

## Approach
- updating acq-models
- updating interface dependency version

#### TODOS and Open Questions
- [ ] Has to be merged together with folio-org/mod-orders#244


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [x] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
