### PR TITLE
MODGOBI-109: Avoid using default FundId if fundId not found

### DIFF
--- a/src/main/resources/ListedElectronicMonograph.json
+++ b/src/main/resources/ListedElectronicMonograph.json
@@ -79,9 +79,7 @@
           "field": "FUND_ID",
           "dataSource": {
             "from": "//FundCode",
-            "default": "*",
-            "translation": "lookupFundId",
-            "translateDefault": true
+            "translation": "lookupFundId"
           }
         },
         {

--- a/src/main/resources/ListedElectronicSerial.json
+++ b/src/main/resources/ListedElectronicSerial.json
@@ -64,9 +64,7 @@
           "field": "FUND_ID",
           "dataSource": {
             "from": "//FundCode",
-            "default": "*",
-            "translation": "lookupFundId",
-            "translateDefault": true
+            "translation": "lookupFundId"
           }
         },
         {

--- a/src/main/resources/ListedPrintMonograph.json
+++ b/src/main/resources/ListedPrintMonograph.json
@@ -64,9 +64,7 @@
           "field": "FUND_ID",
           "dataSource": {
             "from": "//FundCode",
-            "default": "*",
-            "translation": "lookupFundId",
-            "translateDefault": true
+            "translation": "lookupFundId"
           }
         },
         {

--- a/src/main/resources/ListedPrintSerial.json
+++ b/src/main/resources/ListedPrintSerial.json
@@ -48,9 +48,7 @@
           "field": "FUND_ID",
           "dataSource": {
             "from": "//FundCode",
-            "default": "*",
-            "translation": "lookupFundId",
-            "translateDefault": true
+            "translation": "lookupFundId"
           }
         },
         {

--- a/src/main/resources/UnlistedPrintMonograph.json
+++ b/src/main/resources/UnlistedPrintMonograph.json
@@ -64,9 +64,7 @@
           "field": "FUND_ID",
           "dataSource": {
             "from": "//FundCode",
-            "default": "*",
-            "translation": "lookupFundId",
-            "translateDefault": true
+            "translation": "lookupFundId"
           }
         },
         {

--- a/src/main/resources/UnlistedPrintSerial.json
+++ b/src/main/resources/UnlistedPrintSerial.json
@@ -48,9 +48,7 @@
           "field": "FUND_ID",
           "dataSource": {
             "from": "//FundCode",
-            "default": "*",
-            "translation": "lookupFundId",
-            "translateDefault": true
+            "translation": "lookupFundId"
           }
         },
         {

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -669,7 +669,7 @@ public class GOBIIntegrationServiceResourceImplTest {
 
   @Test
   public final void testPostGobiOrdersNoFundsExist() throws Exception {
-    logger.info("Begin: Testing for checking if productId is set if there are no productIdTypes in the environment");
+    logger.info("Begin: Testing for checking if FundId is not set if there are no Funds in the environment");
 
     final String body = getMockData(PO_LISTED_ELECTRONIC_MONOGRAPH_PATH);
 
@@ -678,8 +678,8 @@ public class GOBIIntegrationServiceResourceImplTest {
     assertNotNull(order.getPoLineNumber());
 
     List<JsonObject> fundsRequests = MockServer.serverRqRs.get(FUNDS, HttpMethod.GET);
-    // 2 calls must be made to identifiers endpoint
-    assertEquals(2, fundsRequests.size());
+    // 1 call must be made to Funds endpoint, as there is no default mapping
+    assertEquals(1, fundsRequests.size());
 
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
@@ -688,7 +688,7 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     assertNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
 
-    logger.info("End: Testing for checking if productId is set if there are no productIdTypes in the environment");
+    logger.info("End: Testing for checking if FundId is not set if there are no Funds in the environment");
   }
 
   @Test


### PR DESCRIPTION
https://issues.folio.org/browse/MODGOBI-109

## Purpose
Previously we were not able to edit a fund on open orders , but now that has changed and having a random fundId be assigned if a fund Id is not found with a given fundcode is confusing, so changing the logic to not send a fundId if one is not found

## Approach
- Remove the default translation, and do not send any fund Id if fund Id sent in GOBI order is not found


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
