### PR TITLE
MODGOBI-109: Removing default DistributionType if there is no FundId

### DIFF
--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -674,7 +674,7 @@ public class Mapper {
   }
 
   private void mapFundDistibution(List<CompletableFuture<?>> futures, FundDistribution fundDistribution, Document doc) {
-    if (isValidFundId(futures,fundDistribution, doc)) {
+    if (isValidFundId(futures, fundDistribution, doc)) {
       Optional.ofNullable(mappings.get(Mapping.Field.FUND_CODE))
         .ifPresent(field -> futures.add(field.resolve(doc)
           .thenAccept(o -> fundDistribution.setCode((String) o))

--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -674,25 +674,35 @@ public class Mapper {
   }
 
   private void mapFundDistibution(List<CompletableFuture<?>> futures, FundDistribution fundDistribution, Document doc) {
+    if (isValidFundId(futures,fundDistribution, doc)) {
+      Optional.ofNullable(mappings.get(Mapping.Field.FUND_CODE))
+        .ifPresent(field -> futures.add(field.resolve(doc)
+          .thenAccept(o -> fundDistribution.setCode((String) o))
+          .exceptionally(Mapper::logException)));
+
+      Optional.ofNullable(mappings.get(Mapping.Field.FUND_PERCENTAGE))
+        .ifPresent(field -> futures.add(field.resolve(doc)
+          .thenAccept(o -> fundDistribution.withDistributionType(FundDistribution.DistributionType.PERCENTAGE)
+            .setValue((Double) o))
+          .exceptionally(Mapper::logException)));
+
+      Optional.ofNullable(mappings.get(Mapping.Field.ENCUMBERANCE))
+        .ifPresent(field -> futures.add(field.resolve(doc)
+          .thenAccept(o -> fundDistribution.setEncumbrance((String) o))
+          .exceptionally(Mapper::logException)));
+    } else {
+      fundDistribution.withDistributionType(null);
+    }
+  }
+
+
+  private boolean isValidFundId(List<CompletableFuture<?>> futures, FundDistribution fundDistribution, Document doc) {
     Optional.ofNullable(mappings.get(Mapping.Field.FUND_ID))
       .ifPresent(field -> futures.add(field.resolve(doc)
         .thenAccept(o -> fundDistribution.setFundId((String) o))
         .exceptionally(Mapper::logException)));
 
-    Optional.ofNullable(mappings.get(Mapping.Field.FUND_CODE))
-      .ifPresent(field -> futures.add(field.resolve(doc)
-        .thenAccept(o -> fundDistribution.setCode((String) o))
-        .exceptionally(Mapper::logException)));
-
-    Optional.ofNullable(mappings.get(Mapping.Field.FUND_PERCENTAGE))
-      .ifPresent(field -> futures.add(field.resolve(doc)
-        .thenAccept(o -> fundDistribution.withDistributionType(FundDistribution.DistributionType.PERCENTAGE).setValue((Double) o))
-        .exceptionally(Mapper::logException)));
-
-    Optional.ofNullable(mappings.get(Mapping.Field.ENCUMBERANCE))
-      .ifPresent(field -> futures.add(field.resolve(doc)
-        .thenAccept(o -> fundDistribution.setEncumbrance((String) o))
-        .exceptionally(Mapper::logException)));
+    return StringUtils.isNotEmpty(fundDistribution.getFundId());
   }
 
   private void mapLocation(List<CompletableFuture<?>> futures, Location location, Document doc) {

--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -450,7 +450,7 @@ public class PostGobiOrdersHelper {
 
   public CompletableFuture<String> getOrPlaceOrder(CompositePurchaseOrder compPO) {
     return checkExistingOrder(compPO).thenCompose(isExisting -> {
-      if (isExisting) {
+      if (Boolean.TRUE.equals(isExisting)) {
         logger.info("Order already exists, retrieving the PO Line Number", Json.encodePrettily(compPO));
         return getExistingOrderById(compPO);
       }

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -686,7 +687,8 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     verifyRequiredFieldsAreMapped(compPO);
 
-    assertNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    //Fund Distribution List must be empty, with no proper FundId
+    assertEquals(Collections.emptyList(), compPO.getCompositePoLines().get(0).getFundDistribution());
 
     logger.info("End: Testing for checking if FundId is not set if there are no Funds in the environment");
   }


### PR DESCRIPTION
https://issues.folio.org/browse/MODGOBI-109

## Purpose
The FundDistribution schema has a default value of DistributionType, hence it was still setting the funDistribution Object without a code which is a mandatory field in Orders schema

## Approach
- Remove the DistributionType if the fundId is not valid
- Do not set the fundDistribution object when there are no values
- Also fixed a minor equals comparison with a Boolean(It could throw a potential NPE ) 


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
