### PR TITLE
MODGOBI-183: Mapper.multiply ignores a single value

### DIFF
--- a/src/main/java/org/folio/gobi/Mapper.java
+++ b/src/main/java/org/folio/gobi/Mapper.java
@@ -973,18 +973,14 @@ public class Mapper {
   }
 
   public static String multiply(NodeList nodes) {
-    if (nodes != null && nodes.getLength() > 1) {
-      BigDecimal product = null;
-      for (var i = 0; i < nodes.getLength(); i++) {
-        if (product == null) {
-          product = new BigDecimal(nodes.item(i).getTextContent());
-        } else {
-          product = product.multiply(new BigDecimal(nodes.item(i).getTextContent()));
-        }
-      }
-      return String.valueOf(product);
+    if (nodes == null || nodes.getLength() < 1) {
+      return null;
     }
-    return null;
+    BigDecimal product = new BigDecimal(nodes.item(0).getTextContent());
+    for (var i = 1; i < nodes.getLength(); i++) {
+      product = product.multiply(new BigDecimal(nodes.item(i).getTextContent()));
+    }
+    return String.valueOf(product);
   }
 
   public static List<String> splitStringIntoList(String tags, String delimiter) {

--- a/src/test/java/org/folio/gobi/MapperTest.java
+++ b/src/test/java/org/folio/gobi/MapperTest.java
@@ -22,10 +22,9 @@ class MapperTest {
     assertThat(multiply(), is(nullValue()));
   }
 
-  // TODO: should this be 2.6?
   @Test
   void multiplySingle() {
-    assertThat(multiply("2.6"), is(nullValue()));
+    assertThat(multiply("2.6"), is("2.6"));
   }
 
   @Test


### PR DESCRIPTION
Null is returned when feeding a single element list into org.folio.gobi.Mapper.multiply.

This should return the single element and not null to be more intuitive and to parallel the concat method that also returns the single element.