### PR TITLE
Increase version of mod-configuration client in order to fix karate tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
     <sonar.exclusions>**/models/**.java, **/domain/**.java, **/completablefuture/FolioVertxCompletableFuture.java</sonar.exclusions>
     <sonar.test.exclusions>**/*Test.java</sonar.test.exclusions>
     <jmockit.version>1.49</jmockit.version>
-    <mod-configuration-client.version>5.8.0</mod-configuration-client.version>
+    <mod-configuration-client.version>5.9.1-SNAPSHOT</mod-configuration-client.version>
     <jupiter.version>5.9.0</jupiter.version>
     <log4j.version>2.19.0</log4j.version>
     <argLine />


### PR DESCRIPTION
There is a lot of failures in karate tests today,
In logs in karate report I see 10 occurences of this error:
status code was: 500, expected: 201, response time in milliseconds: 282, url: https://folio-testing-karate-okapi.ci.folio.org/orders/order-lines, response: { "errors" : [ { "message" : "Generic error", "code" : "genericError", "parameters" : [ ], "cause" : "Unrecognized field \"recordsSource\" (class org.folio.rest.jaxrs.model.Config), not marked as ignorable (10 known properties: \"default\", \"userId\", \"id\", \"module\", \"configName\", \"metadata\", \"enabled\", \"code\", \"description\", \"value\"])\n at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: org.folio.rest.jaxrs.model.Configs[\"configs\"]->java.util.ArrayList[0]->org.folio.rest.jaxrs.model.Config[\"recordsSource\"])" } ], "total_records" : 1 }
Need to increase version of mod-configuration-client to the latest snapshot one