### PR TITLE
Remove FolioVertxCompletableFuture from sonar.exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     <raml-module-builder.version>35.0.3</raml-module-builder.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>4.3.4</vertx.version>
-    <sonar.exclusions>**/models/**.java, **/domain/**.java, **/completablefuture/FolioVertxCompletableFuture.java</sonar.exclusions>
+    <sonar.exclusions>**/models/**.java, **/domain/**.java</sonar.exclusions>
     <sonar.test.exclusions>**/*Test.java</sonar.test.exclusions>
     <jmockit.version>1.49</jmockit.version>
     <mod-configuration-client.version>5.9.1</mod-configuration-client.version>


### PR DESCRIPTION

## Purpose
Removed FolioVertxCompletableFuture from sonar.exclusions after https://github.com/folio-org/mod-gobi/pull/187 merged