### PR TITLE
[MODORDERS-1269] Single po line schema, no sub-object

### DIFF
--- a/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
+++ b/src/main/java/org/folio/rest/impl/PostGobiOrdersHelper.java
@@ -204,7 +204,7 @@ public class PostGobiOrdersHelper {
     try {
       return restClient.post(ORDERS_ENDPOINT, JsonObject.mapFrom(compPO))
         .map(body -> {
-          logger.info("Response from mod-orders: \n {}", body::encodePrettily);
+          logger.debug("Response from mod-orders: \n {}", body::encodePrettily);
           return body.getJsonArray("poLines").getJsonObject(FIRST_ELEM).getString("poLineNumber");
         })
         .toCompletionStage().toCompletableFuture();

--- a/src/test/java/org/folio/gobi/MappingTest.java
+++ b/src/test/java/org/folio/gobi/MappingTest.java
@@ -30,9 +30,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.gobi.domain.LocationTranslationResult;
-import org.folio.rest.acq.model.CompositePoLine;
 import org.folio.rest.acq.model.CompositePurchaseOrder;
 import org.folio.rest.acq.model.Location;
+import org.folio.rest.acq.model.PoLine;
 import org.folio.rest.jaxrs.model.DataSource.Translation;
 import org.folio.rest.jaxrs.model.Mapping;
 import org.folio.rest.jaxrs.model.OrderMappings;
@@ -146,7 +146,7 @@ public class MappingTest {
     Mapper mapper = new Mapper(lookupService);
     var bindingResult = mapper.map(mappings, gobiOrder).get();
     CompositePurchaseOrder compPO = bindingResult.getResult();
-    CompositePoLine pol = compPO.getCompositePoLines().get(0);
+    PoLine pol = compPO.getPoLines().get(0);
 
     //Then
     Location location = pol.getLocations().get(0);
@@ -203,9 +203,9 @@ public class MappingTest {
     Mapper mapper = new Mapper(lookupService);
     var bindingResult = mapper.map(mappings, gobiOrder).get();
     CompositePurchaseOrder compPO = bindingResult.getResult();
-    CompositePoLine pol = compPO.getCompositePoLines().get(0);
+    PoLine pol = compPO.getPoLines().get(0);
     //Then
-    assertThat(pol.getOrderFormat(), is(CompositePoLine.OrderFormat.PHYSICAL_RESOURCE));
+    assertThat(pol.getOrderFormat(), is(PoLine.OrderFormat.PHYSICAL_RESOURCE));
     assertThat(compPO.getPoNumberSuffix(), equalTo(sufId));
     assertThat(compPO.getPoNumberPrefix(), equalTo(prefId));
     assertThat(compPO.getBillTo(), equalTo(vendorId));
@@ -252,9 +252,9 @@ public class MappingTest {
     Mapper mapper = new Mapper(lookupService);
     var bindingResult = mapper.map(mappings, gobiOrder).get();
     CompositePurchaseOrder compPO = bindingResult.getResult();
-    CompositePoLine pol = compPO.getCompositePoLines().get(0);
+    PoLine pol = compPO.getPoLines().get(0);
     //Then
-    assertThat(pol.getOrderFormat(), is(CompositePoLine.OrderFormat.PHYSICAL_RESOURCE));
+    assertThat(pol.getOrderFormat(), is(PoLine.OrderFormat.PHYSICAL_RESOURCE));
     assertThat(compPO.getWorkflowStatus(), equalTo(CompositePurchaseOrder.WorkflowStatus.PENDING));
     assertNotNull(bindingResult.getError(PREFIX));
   }
@@ -297,9 +297,9 @@ public class MappingTest {
     Mapper mapper = new Mapper(lookupService);
     var bindingResult = mapper.map(mappings, gobiOrder).get();
     CompositePurchaseOrder compPO = bindingResult.getResult();
-    CompositePoLine pol = compPO.getCompositePoLines().get(0);
+    PoLine pol = compPO.getPoLines().get(0);
     //Then
-    assertThat(pol.getOrderFormat(), is(CompositePoLine.OrderFormat.PHYSICAL_RESOURCE));
+    assertThat(pol.getOrderFormat(), is(PoLine.OrderFormat.PHYSICAL_RESOURCE));
     assertThat(compPO.getWorkflowStatus(), equalTo(CompositePurchaseOrder.WorkflowStatus.PENDING));
     assertNotNull(bindingResult.getError(PREFIX));
   }

--- a/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
+++ b/src/test/java/org/folio/rest/impl/GOBIIntegrationServiceResourceImplTest.java
@@ -41,8 +41,8 @@ import org.apache.logging.log4j.Logger;
 import org.folio.gobi.LookupService;
 import org.folio.rest.ResourcePaths;
 import org.folio.rest.RestVerticle;
-import org.folio.rest.acq.model.CompositePoLine;
 import org.folio.rest.acq.model.CompositePurchaseOrder;
+import org.folio.rest.acq.model.PoLine;
 import org.folio.rest.gobi.model.GobiResponse;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.hamcrest.Matchers;
@@ -255,15 +255,15 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
-    compPO.getCompositePoLines().get(0).withDescription("test");
+    compPO.getPoLines().get(0).withDescription("test");
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     //make sure that the qualifier field is empty
-    assertNull(compPO.getCompositePoLines().get(0).getDetails().getProductIds().get(0).getQualifier());
-    assertEquals("9781410352224",compPO.getCompositePoLines().get(0).getDetails().getProductIds().get(0).getProductId());
+    assertNull(compPO.getPoLines().get(0).getDetails().getProductIds().get(0).getQualifier());
+    assertEquals("9781410352224",compPO.getPoLines().get(0).getDetails().getProductIds().get(0).getProductId());
 
-    assertFalse(compPO.getCompositePoLines().get(0).getDescription().isEmpty());
+    assertFalse(compPO.getPoLines().get(0).getDescription().isEmpty());
 
     logger.info("End: Testing for 201 - posted order listed electronic monograph");
   }
@@ -289,17 +289,17 @@ public class GOBIIntegrationServiceResourceImplTest {
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
      CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
      verifyRequiredFieldsAreMapped(compPO);
-    assertEquals("Description from Custom Mapping", compPO.getCompositePoLines().get(0).getPoLineDescription());
+    assertEquals("Description from Custom Mapping", compPO.getPoLines().get(0).getPoLineDescription());
     // verify if the currency specified in the request is used
-    assertEquals("GBP", compPO.getCompositePoLines().get(0).getCost().getCurrency());
+    assertEquals("GBP", compPO.getPoLines().get(0).getCost().getCurrency());
 
     // MODGOBI-61 - check createInventory populated for eresource only
-    assertNotNull(compPO.getCompositePoLines().get(0).getEresource().getCreateInventory());
-    assertNull(compPO.getCompositePoLines().get(0).getPhysical());
+    assertNotNull(compPO.getPoLines().get(0).getEresource().getCreateInventory());
+    assertNull(compPO.getPoLines().get(0).getPhysical());
 
     verifyRequiredFieldsAreMapped(compPO);
     assertFalse(compPO.getAcqUnitIds().isEmpty());
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for 201 - posted order listed electronic serial");
   }
@@ -323,13 +323,13 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
-    assertThat(compPO.getCompositePoLines().get(0).getCost().getListUnitPriceElectronic(), nullValue());
-    assertThat(compPO.getCompositePoLines().get(0).getCost().getListUnitPrice(), equalTo(14.95));
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
-    assertNotNull(compPO.getCompositePoLines().get(0).getAcquisitionMethod());
+    assertThat(compPO.getPoLines().get(0).getCost().getListUnitPriceElectronic(), nullValue());
+    assertThat(compPO.getPoLines().get(0).getCost().getListUnitPrice(), equalTo(14.95));
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getAcquisitionMethod());
 
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for 201 - posted order listed print monograph");
   }
@@ -351,11 +351,11 @@ public class GOBIIntegrationServiceResourceImplTest {
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     // verify if default currency is used
-    assertEquals("USD", compPO.getCompositePoLines().get(0).getCost().getCurrency());
+    assertEquals("USD", compPO.getPoLines().get(0).getCost().getCurrency());
 
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
-    assertTrue(compPO.getCompositePoLines().get(0).getTags().getTagList().isEmpty());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertTrue(compPO.getPoLines().get(0).getTags().getTagList().isEmpty());
 
     logger.info("End: Testing for 201 - posted order listed print serial");
   }
@@ -380,7 +380,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for 201 - posted order unlisted print monograph");
   }
@@ -401,11 +401,11 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
-    assertEquals("USD", compPO.getCompositePoLines().get(0).getCost().getCurrency());
+    assertEquals("USD", compPO.getPoLines().get(0).getCost().getCurrency());
 
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
-    assertTrue(compPO.getCompositePoLines().get(0).getTags().getTagList().isEmpty());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertTrue(compPO.getPoLines().get(0).getTags().getTagList().isEmpty());
 
     logger.info("End: Testing for 201 - posted order unlisted print serial");
   }
@@ -455,7 +455,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for 201 - posted order listed print monograph");
   }
@@ -477,10 +477,10 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
-    assertEquals(UNSPECIFIED_MATERIAL_TYPE_ID, compPO.getCompositePoLines().get(0).getEresource().getMaterialType());
+    assertEquals(UNSPECIFIED_MATERIAL_TYPE_ID, compPO.getPoLines().get(0).getEresource().getMaterialType());
 
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for falling back to the unspecified material id, if a non existent code is sent");
   }
@@ -524,7 +524,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for falling back to the first location id, if a non existent code is sent");
   }
@@ -543,7 +543,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     List<JsonObject> postedOrder = MockServer.serverRqRs.get(PURCHASE_ORDER, HttpMethod.POST);
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
     assertFalse(compPO.getAcqUnitIds().isEmpty());
 
     logger.info("End: Testing for falling back to the first location id, if a non existent code is sent");
@@ -568,7 +568,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     CompositePurchaseOrder compPO = postedOrder.get(0)
       .mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for falling back to the first product id, if a non existent code is sent");
   }
@@ -592,8 +592,8 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getContributors().get(0).getContributorNameTypeId());
-    assertNotNull(compPO.getCompositePoLines().get(0).getContributors().get(0).getContributor());
+    assertNotNull(compPO.getPoLines().get(0).getContributors().get(0).getContributorNameTypeId());
+    assertNotNull(compPO.getPoLines().get(0).getContributors().get(0).getContributor());
 
     logger.info("End: Testing for falling back to the first random contributor name type, if a non existent code is sent");
   }
@@ -617,7 +617,7 @@ public class GOBIIntegrationServiceResourceImplTest {
 
     CompositePurchaseOrder compPO = postedOrder.get(0).mapTo(CompositePurchaseOrder.class);
     verifyRequiredFieldsAreMapped(compPO);
-    assertTrue(compPO.getCompositePoLines().get(0).getContributors().isEmpty());
+    assertTrue(compPO.getPoLines().get(0).getContributors().isEmpty());
 
     logger.info("End: Testing contributor is ignored if contributor name type cannot be resolved");
   }
@@ -641,10 +641,10 @@ public class GOBIIntegrationServiceResourceImplTest {
       .mapTo(CompositePurchaseOrder.class);
     // assert that the productId is mapped, so that if the order is created in Pending state even though
     // there is no ProductIdType
-    assertNull(compPO.getCompositePoLines().get(0).getDetails().getProductIds().get(0).getProductIdType());
-    assertNotNull(compPO.getCompositePoLines().get(0).getDetails().getProductIds().get(0).getProductId());
+    assertNull(compPO.getPoLines().get(0).getDetails().getProductIds().get(0).getProductIdType());
+    assertNotNull(compPO.getPoLines().get(0).getDetails().getProductIds().get(0).getProductId());
     verifyRequiredFieldsAreMapped(compPO);
-    assertNotNull(compPO.getCompositePoLines().get(0).getFundDistribution().get(0).getFundId());
+    assertNotNull(compPO.getPoLines().get(0).getFundDistribution().get(0).getFundId());
 
     logger.info("End: Testing for checking if productId is set if there are no productIdTypes in the environment");
   }
@@ -670,7 +670,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     verifyRequiredFieldsAreMapped(compPO);
 
     //Fund Distribution List must be empty, with no proper FundId
-    assertEquals(Collections.emptyList(), compPO.getCompositePoLines().get(0).getFundDistribution());
+    assertEquals(Collections.emptyList(), compPO.getPoLines().get(0).getFundDistribution());
 
     logger.info("End: Testing for checking if FundId is not set if there are no Funds in the environment");
   }
@@ -899,9 +899,9 @@ public class GOBIIntegrationServiceResourceImplTest {
   private void validateProductIDAndQualifier(String productID, String qualifier) {
     Map<String, List<JsonObject>> postOrder = MockServer.serverRqRs.column(HttpMethod.POST);
     CompositePurchaseOrder compPO = postOrder.get(PURCHASE_ORDER).get(0).mapTo(CompositePurchaseOrder.class);
-    assertNotNull(compPO.getCompositePoLines().get(0).getDetails().getProductIds().get(0).getQualifier());
-    assertEquals(productID,compPO.getCompositePoLines().get(0).getDetails().getProductIds().get(0).getProductId());
-    assertEquals(qualifier,compPO.getCompositePoLines().get(0).getDetails().getProductIds().get(0).getQualifier());
+    assertNotNull(compPO.getPoLines().get(0).getDetails().getProductIds().get(0).getQualifier());
+    assertEquals(productID,compPO.getPoLines().get(0).getDetails().getProductIds().get(0).getProductId());
+    assertEquals(qualifier,compPO.getPoLines().get(0).getDetails().getProductIds().get(0).getQualifier());
   }
 
   /**
@@ -965,10 +965,10 @@ public class GOBIIntegrationServiceResourceImplTest {
   private void verifyResourceCreateInventoryNotMapped() {
     Map<String, List<JsonObject>> postOrder = MockServer.serverRqRs.column(HttpMethod.POST);
     CompositePurchaseOrder compPO = postOrder.get(PURCHASE_ORDER).get(0).mapTo(CompositePurchaseOrder.class);
-    compPO.getCompositePoLines().stream()
+    compPO.getPoLines().stream()
       .filter(line -> line.getEresource() != null)
       .forEach(line -> assertNull(line.getEresource().getCreateInventory()));
-    compPO.getCompositePoLines().stream()
+    compPO.getPoLines().stream()
       .filter(line -> line.getPhysical() != null)
       .forEach(line -> assertNull(line.getPhysical().getCreateInventory()));
   }
@@ -981,7 +981,7 @@ public class GOBIIntegrationServiceResourceImplTest {
     assertNotNull(compPO.getVendor());
     assertNotNull(compPO.getOrderType());
 
-    CompositePoLine poLine = compPO.getCompositePoLines().get(0);
+    PoLine poLine = compPO.getPoLines().get(0);
     assertNotNull(poLine.getAcquisitionMethod());
     assertNotNull(poLine.getCost());
     assertNotNull(poLine.getOrderFormat());
@@ -1090,7 +1090,7 @@ public class GOBIIntegrationServiceResourceImplTest {
       compPO.put(ID, randomUUID().toString());
       String poNumber = "PO_" + randomDigits(10);
       compPO.put("poNumber", poNumber);
-      compPO.getJsonArray("compositePoLines").forEach(line -> {
+      compPO.getJsonArray("poLines").forEach(line -> {
         JsonObject poLine = (JsonObject) line;
         poLine.put(ID, randomUUID().toString());
         poLine.put("poLineNumber", poNumber + "-1");

--- a/src/test/resources/MockData/compositePurchaseOrder.json
+++ b/src/test/resources/MockData/compositePurchaseOrder.json
@@ -19,15 +19,12 @@
   "totalItems" : 1,
   "vendor" : "588b5c42-8634-4af7-bc9b-5e0116ed96b6",
   "workflowStatus" : "Open",
-  "compositePoLines" : [ {
+  "poLines" : [ {
     "id" : "0fe2ce39-1011-4316-bd2c-490ac57c78bf",
     "poLineNumber" : "PO_6733180275-1",
     "purchaseOrderId" : "22dd4cfb-3e46-41cb-a9bf-f4b2bfa0b991",
     "checkinItems" : false,
     "acquisitionMethod" : "306489dd-0053-49ee-a068-c316444a8f55",
-    "alerts" : [ {
-      "alert" : "Test Data"
-    } ],
     "cancellationRestrictionNote" : "Test Data",
     "claims" : [ {
       "claimed" : true,
@@ -79,10 +76,6 @@
     "poLineDescription" : "Description from Custom Mapping",
     "publisher" : "GALE ONLINE",
     "receiptStatus" : "Receipt Not Required",
-    "reportingCodes" : [ {
-      "code" : "TestReportingCode",
-      "description" : "Test Data"
-    } ],
     "selector" : "Test Data",
     "source" : "API",
     "tags": {

--- a/src/test/resources/PostGobiOrdersHelper/valid_po_line_collection.json
+++ b/src/test/resources/PostGobiOrdersHelper/valid_po_line_collection.json
@@ -8,9 +8,6 @@
         "isPackage": false,
         "agreementId": "bdc75fea-fed8-11e8-8eb2-f2801f1b9fd1",
         "acquisitionMethod": "73d14bc5-d131-48c6-b380-f8e62f63c8f3",
-        "alerts": [
-          "9a665b22-9fe5-4c95-b4ee-837a5433c95d"
-        ],
         "cancellationRestriction": false,
         "cancellationRestrictionNote": "ABCDEFGHIJKLMNOPQRSTUVW",
         "claims": [
@@ -97,11 +94,6 @@
         "purchaseOrderId": "d79b0bcc-DcAD-1E4E-Abb7-DbFcaD5BB3bb",
         "receiptDate": "2018-10-09T00:00:00.000Z",
         "receiptStatus": "Awaiting Receipt",
-        "reportingCodes": [
-          "5926dcd7-85f5-4504-8283-712595ebc38b",
-          "fa316c04-8101-4e72-8aaf-01281bac718f",
-          "ea68b696-3125-4940-bf91-1d128323473e"
-        ],
         "requester": "Leo Bulero",
         "rush": true,
         "selector": "ABCD",


### PR DESCRIPTION
## Purpose
[MODORDERS-1269](https://folio-org.atlassian.net/browse/MODORDERS-1269) - Remove alerts and reporting codes from order lines, use a single order line schema

## Approach
- Use a single po line schema, no more "composite po line"

## Related PRs
- See [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/477)
- Required for compilation: [acq-models](https://github.com/folio-org/acq-models/pull/520)

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
