### PR TITLE
MODGOBI-223: Fix SchemaFactory XML External Entity (XXE) vulnerabilities

### DIFF
--- a/src/main/java/org/folio/gobi/GobiPurchaseOrderParser.java
+++ b/src/main/java/org/folio/gobi/GobiPurchaseOrderParser.java
@@ -42,6 +42,12 @@ public class GobiPurchaseOrderParser {
   private GobiPurchaseOrderParser() {
     try {
       SchemaFactory schemaFactory = SchemaFactory.newInstance(W3C_XML_SCHEMA_NS_URI);
+      // Disable XML External Entity (XXE) vulnerabilities
+      // https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet
+      // https://semgrep.dev/docs/cheat-sheets/java-xxe
+      schemaFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
       schemaFactory.setResourceResolver(new ResourceResolver());
       Schema schema = schemaFactory.newSchema(new StreamSource(this.getClass().getClassLoader().getResourceAsStream(PURCHASE_ORDER_SCHEMA)));
       validator = schema.newValidator();
@@ -61,11 +67,11 @@ public class GobiPurchaseOrderParser {
 
       //https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet
       // By disabling DTD, almost all XXE attacks will be prevented.
-      factory.setFeature(DTD_FEATURE, Boolean.TRUE);
+      factory.setFeature(DTD_FEATURE, true);
       //Protect against Denial of Service attack and remote file access.
-      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, Boolean.TRUE);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
       // Protect against external DTDs
-      factory.setFeature(EXTERNAL_DTD_FEATURE, Boolean.FALSE);
+      factory.setFeature(EXTERNAL_DTD_FEATURE, false);
       // Protect from XML Schema
       factory.setXIncludeAware(false);
       factory.setExpandEntityReferences(false);


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODGOBI-223

## Purpose
Prevent XML External Entity (XXE) vulnerabilities.

## Approach
Disable XML External Entity in SchemaFactory preventing XML External Entity (XXE) vulnerabilities.

Replace Boolean.TRUE with true and Boolean.FALSE with false. The unboxing of the current code results in the correct value but hides it from static code analysis of DocumentBuilderFactory settings regarding XML External Entity (XXE) vulnerabilities.

#### TODOS and Open Questions
- [x] Check logging.

## Learning
* Follow XXE prevention guidelines:
** https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet
** https://semgrep.dev/docs/cheat-sheets/java-xxe
* Avoid boxing/unboxing.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.